### PR TITLE
fix(aws): add links to release

### DIFF
--- a/docs/aws/Index.rst
+++ b/docs/aws/Index.rst
@@ -13,6 +13,7 @@ Documentation
 
    GettingStarted/Index.rst
    Upgrading.rst
+   Uninstalling.rst
    Simulator.rst
    ContinuousDeployment.rst
    Authentication.rst
@@ -21,5 +22,4 @@ Documentation
    HistoricalData.rst
    ContinuousIntegration.rst
    UnwiredLabsAPI.rst
-   Uninstalling.rst
    SNI.rst

--- a/docs/aws/Upgrading.rst
+++ b/docs/aws/Upgrading.rst
@@ -5,7 +5,7 @@ Upgrading an existing installation
 
 If you already have an installation and you want to upgrade to the latest release, perform the following steps:
 
-1. Review the `release notes for the nRF Asset Tracker for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/releases>`_ and pay close attention to **Breaking Changes**.
+1. See the `release notes for the nRF Asset Tracker for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/releases>`_ and pay close attention to *Breaking Changes*.
 
 #. Pull in the changes and perform the update:
 

--- a/docs/aws/Upgrading.rst
+++ b/docs/aws/Upgrading.rst
@@ -21,7 +21,7 @@ Upgrading an existing *Cat Tracker web application* installation
 
 If you already have an installation and you want to upgrade to the latest release, perform the following steps:
 
-1. Review the `release notes for the Cat Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js/releases>`_ and pay close attention to **Breaking Changes**.
+1. See the `release notes for the Cat Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js/releases>`_ and pay close attention to *Breaking Changes*.
 
 #. Pull in the changes and perform the update:
 

--- a/docs/aws/Upgrading.rst
+++ b/docs/aws/Upgrading.rst
@@ -25,10 +25,10 @@ If you already have an installation and you want to upgrade to the latest releas
 
 #. Pull in the changes and perform the update:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    git pull
-    npm ci
+       git pull
+       npm ci
 
 Publishing the upgraded *Cat Tracker web application* to AWS
 ------------------------------------------------------------

--- a/docs/aws/Upgrading.rst
+++ b/docs/aws/Upgrading.rst
@@ -5,24 +5,32 @@ Upgrading an existing installation
 
 If you already have an installation and you want to upgrade to the latest release, perform the following steps:
 
-.. code-block:: bash
+1. Review the `release notes for the nRF Asset Tracker for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/releases>`_ and pay close attention to **Breaking Changes**.
 
-    git pull
-    npm ci
-    npx tsc
-    npx cdk deploy '*' 
+#. Pull in the changes and perform the update:
+
+   .. code-block:: bash
+
+       git pull
+       npm ci
+       npx tsc
+       npx cdk deploy '*' 
 
 Upgrading an existing *Cat Tracker web application* installation
 ****************************************************************
 
-If you already have an installation and you want to upgrade to the latest release, run the following commands:
+If you already have an installation and you want to upgrade to the latest release, perform the following steps:
+
+1. Review the `release notes for the Cat Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js/releases>`_ and pay close attention to **Breaking Changes**.
+
+#. Pull in the changes and perform the update:
 
 .. code-block:: bash
 
     git pull
     npm ci
 
-Publishing the upgrade to AWS
------------------------------
+Publishing the upgraded *Cat Tracker web application* to AWS
+------------------------------------------------------------
 
 If you want to publish the upgrade to AWS, perform the steps for the initial installation as described in :ref:`aws-getting-started-app`.


### PR DESCRIPTION
This adds links to the release for the AWS project
and the web application project, so users can
review them before upgrading.

This also moves the Uninstalling instructions
right below in the menu.