### PR TITLE
node cli flash does not work on WSL 2

### DIFF
--- a/docs/devices/FlashingCertificate/CLI.rst
+++ b/docs/devices/FlashingCertificate/CLI.rst
@@ -5,14 +5,14 @@ Provisioning using the CLI
 
 .. body_start
 
-.. warning::
-
-    Flashing using the CLI is not supported on WSL 2 right now because `it lacks support for serial devices <https://github.com/microsoft/WSL/issues/4322>`_.
-    Instead, :ref:`use nRF Connect for Desktop to provision your certificates <devices-provisioning-certificate-desktop>` and then follow the same instructions to flash your firmware as well.
-
 .. note::
 
-   To provision the device certificate using CLI, you must have `Segger JLink <https://www.segger.com/downloads/jlink/>`_ installed in your path.
+   Provisioning the certificates and programming the firmware through CLI are not currently supported on WSL 2 since it lacks support for serial devices. 
+   For more information, see the `issue on WSL2 <https://github.com/microsoft/WSL/issues/4322>`_.
+   Instead, :ref:`use nRF Connect for Desktop to provision your certificates <devices-provisioning-certificate-desktop>` and then :ref:`program the firmware <program-the-firmware>`.
+
+   
+To provision the device certificate using CLI, you must have `Segger JLink <https://www.segger.com/downloads/jlink/>`_ installed in your path.
 
 Use the CLI to provision the device certificates:
 

--- a/docs/devices/FlashingCertificate/CLI.rst
+++ b/docs/devices/FlashingCertificate/CLI.rst
@@ -5,6 +5,11 @@ Provisioning using the CLI
 
 .. body_start
 
+.. warning::
+
+    Flashing using the CLI is not supported on WSL 2 right now because `it lacks support for serial devices <https://github.com/microsoft/WSL/issues/4322>`_.
+    Instead, :ref:`use nRF Connect for Desktop to provision your certificates <devices-provisioning-certificate-desktop>` and then follow the same instructions to flash your firmware as well.
+
 .. note::
 
    To provision the device certificate using CLI, you must have `Segger JLink <https://www.segger.com/downloads/jlink/>`_ installed in your path.

--- a/docs/devices/FlashingCertificate/Desktop.rst
+++ b/docs/devices/FlashingCertificate/Desktop.rst
@@ -18,8 +18,8 @@ To provision the certificate using LTE Link Monitor, complete the following step
 
    For programming, use the following files:
  
-   *   Thingy:91 -  `thingy91_at_client_increased_buf.hex <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/releases/download/v4.2.1/thingy91_at_client_increased_buf.hex>`_
-   *   nRF9160 DK - `91dk_at_client_increased_buf.hex <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/releases/download/v5.9.2/91dk_at_client_increased_buf.hex>`_
+   *   Thingy:91 -  `thingy91_at_client_increased_buf.hex <https://nordicsemiconductor.github.io/at_client-hex/at_client-thingy91_nrf9160ns.hex>`_
+   *   nRF9160 DK - `91dk_at_client_increased_buf.hex <https://nordicsemiconductor.github.io/at_client-hex/at_client-nrf9160dk_nrf9160ns.hex>`_
 
    For instructions, see the following documentation:
 

--- a/docs/devices/FlashingCertificate/Desktop.rst
+++ b/docs/devices/FlashingCertificate/Desktop.rst
@@ -21,10 +21,7 @@ To provision the certificate using LTE Link Monitor, complete the following step
    *   Thingy:91 -  `thingy91_at_client_increased_buf.hex <https://nordicsemiconductor.github.io/at_client-hex/at_client-thingy91_nrf9160ns.hex>`_
    *   nRF9160 DK - `91dk_at_client_increased_buf.hex <https://nordicsemiconductor.github.io/at_client-hex/at_client-nrf9160dk_nrf9160ns.hex>`_
 
-   For instructions, see the following documentation:
-
-   *  `Programming the Thingy:91 <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_pgming_thingy91_usb.html>`_
-   *  `Programming the nRF9160 DK <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/common/ncp_programming_applications_nrf9160dk.html>`_
+   For instructions, see :ref:`programming the firmware <program-the-firmware>`.
 
    .. important::
 

--- a/docs/devices/Index.rst
+++ b/docs/devices/Index.rst
@@ -13,6 +13,8 @@ For the device to connect, you need to complete the following steps:
    * `Thingy:91 modem upgrade <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_updating_modem_thingy91_intro.html>`_
 
 #. :ref:`Provision the certificate <devices-provisioning-certificate>`.
+
+   .. _program-the-firmware:
 #. Program the application firmware according to the instructions in the following documentation:
 
    * `nRF9160 DK application firmware update <https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_application_firmware.html>`_


### PR DESCRIPTION
add note on defunct flashing using WSL 2
This also updates the links the AT client hex files