### PR TITLE
fix: move paragraph on features

### DIFF
--- a/docs/aws/ContinuousIntegration.rst
+++ b/docs/aws/ContinuousIntegration.rst
@@ -23,8 +23,6 @@ Since the BDD tests are purely testing based on the public API of the project (w
     This is an advanced topic that is closely tied with the further development and customization of the nRF Asset Tracker for your purposes.
     See the `GitHub project page of the nRF Asset Tracker for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/>`_ for an implementation of the process outlined in this section.
 
-The project also provides an easily understandable description of the available (and implemented) features, in a single folder called `features <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/tree/saga/features>`_.
-
 Running the tests during development
 ************************************
 

--- a/docs/aws/Index.rst
+++ b/docs/aws/Index.rst
@@ -4,7 +4,9 @@ AWS cloud components
 #####################
 
 The nRF Asset Tracker provides a reference implementation of a serverless backend for an IoT product using AWS.
-It is developed using `AWS CDK <https://aws.amazon.com/cdk/>`_ in `TypeScript <https://www.typescriptlang.org/>`_. 
+It is developed using `AWS CDK <https://aws.amazon.com/cdk/>`_ in `TypeScript <https://www.typescriptlang.org/>`_.
+
+The project also provides an easily understandable description of the available (and implemented) features, in a single folder called `features <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/tree/saga/features>`_.
 
 .. toctree::
    :titlesonly:

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -22,8 +22,6 @@ Since the BDD tests are purely testing based on the public API of the project (w
     This is an advanced topic for those who need to further develop and customize the nRF Asset Tracker.
     See the `nRF Asset Tracker for Azure GitHub project page <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js>`_, for the implementation of the process outlined in this section.
 
-The project also provides an easily understandable description of the available (and implemented) features, in a single folder called  `features <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/tree/saga/features>`_.
-
 Prepare your Azure account
 **************************
 

--- a/docs/azure/Index.rst
+++ b/docs/azure/Index.rst
@@ -17,6 +17,8 @@ Azure cloud components
 The nRF Asset Tracker provides a reference implementation of a serverless backend for an IoT product using Azure.
 It is developed using `Azure Resource Manager <https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview>`_ in `TypeScript <https://www.typescriptlang.org/>`_.
 
+The project also provides an easily understandable description of the available (and implemented) features, in a single folder called  `features <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/tree/saga/features>`_.
+
 .. note::
 
    **Recurring costs**


### PR DESCRIPTION
This moves the paragraph to the index page because it is
relevant to everyone who wants to learn about the project,
not just those interested in Continuous Integration, since
it also can be used without CI