### PR TITLE
split firmware instructions per cloud

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -34,6 +34,9 @@ jobs:
             rm -r docs/azure
             cat index.rst | grep -v docs/azure > index-no-azure.rst
             mv index-no-azure.rst index.rst
+            rm -r docs/firmware/azure
+            cat docs/firmware/Index.rst | grep -v azure/ > docs/firmware/Index-no-azure.rst
+            mv docs/firmware/Index-no-azure.rst docs/firmware/Index.rst
           fi
           make html 2> $errlog
           if [[ -s "$errlog" ]]; then

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -36,6 +36,9 @@ jobs:
             rm -r docs/azure
             cat index.rst | grep -v docs/azure > index-no-azure.rst
             mv index-no-azure.rst index.rst
+            rm -r docs/firmware/azure
+            cat docs/firmware/Index.rst | grep -v azure/ > docs/firmware/Index-no-azure.rst
+            mv docs/firmware/Index-no-azure.rst docs/firmware/Index.rst
           fi
           make html 2> $errlog
           if [[ -s "$errlog" ]]; then

--- a/docs/aws/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/aws/GettingStarted/FirmwareConfiguration.rst
@@ -1,10 +1,9 @@
-.. _firmware-configuration:
+.. _aws-firmware-configuration:
 
 Configure the firmware
 ######################
 
-To configure the :ref:`firmware <firmware-index>`, complete the following mandatory steps:
-
+To configure the :ref:`firmware <firmware-aws-index>`, complete the following mandatory steps:
 
 1. Run the following command to print the MQTT endpoint to which your devices will connect:
 
@@ -16,8 +15,7 @@ To configure the :ref:`firmware <firmware-index>`, complete the following mandat
 
 #. Use ``42`` as the value for ``CONFIG_AWS_IOT_SEC_TAG``.
 
-
-After completing the configuration, compile the firmware either :ref:`using your own development environment <firmware-building>` or :ref:`using Docker <firmware-building-docker>` and then :ref:`create the device credentials <aws-device-credentials>`.
+After completing the configuration, compile the firmware either :ref:`using your own development environment <firmware-aws-building>` or :ref:`using Docker <firmware-aws-building-docker>` and then :ref:`create the device credentials <aws-device-credentials>`.
 
 .. note::
 

--- a/docs/azure/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/azure/GettingStarted/FirmwareConfiguration.rst
@@ -1,0 +1,14 @@
+.. _azure-firmware-configuration:
+
+Configure the firmware
+######################
+
+To configure the :ref:`firmware <firmware-azure-index>`, complete the following *mandatory* steps:
+
+1. // FIXME: Implement
+
+After completing the configuration, compile the firmware either :ref:`using your own development environment <firmware-azure-building>` or :ref:`using Docker <firmware-azure-building-docker>` and then :ref:`create the device credentials <azure-device-credentials>`.
+
+.. note::
+
+   See the documentation on `nRF9160: Asset Tracker v2 application <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_ for all the available configuration options.

--- a/docs/azure/GettingStarted/Index.rst
+++ b/docs/azure/GettingStarted/Index.rst
@@ -27,6 +27,7 @@ Before you start the setup of the nRF Asset Tracker on Azure, ensure that you ha
    AzureCLI.rst
    AzureFunctionCoreTools.rst
    Deploy.rst
+   FirmwareConfiguration.rst
    DeviceCredentials.rst
    Webapp.rst
    NextSteps.rst

--- a/docs/devices/FlashingCertificate/CLI.rst
+++ b/docs/devices/FlashingCertificate/CLI.rst
@@ -31,12 +31,12 @@ Provisioning of the certificate using CLI also results in the following actions:
 
     1. Programming of the `AT client sample <https://github.com/NordicSemiconductor/at_client-hex>`_ onto the device.
     #. Provisioning of the :ref:`created device credentials <aws-device-credentials>`.
-    #. Programming of the :ref:`configured and built firmware <firmware-configuration>` to the device.
+    #. Programming of the :ref:`configured and built firmware <aws-firmware-configuration>` to the device.
 
 .. only:: saga
 
     1. Programming of the `AT client sample <https://github.com/NordicSemiconductor/at_client-hex>`_ onto the device
     #. Provisioning of the created device credentials for the respective cloud flavour :ref:`AWS <aws-device-credentials>`, or :ref:`Azure <azure-device-credentials>`
-    #. Programming of the :ref:`configured and built firmware <firmware-configuration>` to the device
+    #. Programming of the :ref:`configured and built firmware <aws-firmware-configuration>` to the device
 
 .. body_end

--- a/docs/devices/TroubleShooting.rst
+++ b/docs/devices/TroubleShooting.rst
@@ -35,8 +35,15 @@ A solution is to switch to a SIM card that grants PSM.
 
 Another solution is to use assisted GPS (A-GPS) to speed up the time to fix.
 
-One form of A-GPS is using SUPL and it can be optionally enabled in the firmware using the `SUPL client  <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/supl_os_client.html>`_.
-The `nRF Asset Tracker firmware project <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws/pull/9>`_ optionally supports building the firmware images with SUPL enabled.
+.. only:: not saga
+
+    One form of A-GPS is using SUPL and it can be optionally enabled in the firmware using the `SUPL client  <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/supl_os_client.html>`_.
+    The `nRF Asset Tracker firmware project <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws/pull/9>`_ optionally supports building the firmware images with SUPL enabled.
+
+.. only:: saga
+
+    One form of A-GPS is using SUPL and it can be optionally enabled in the firmware using the `SUPL client  <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/supl_os_client.html>`_.
+    The nRF Asset Tracker firmware projects `for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws/pull/9>`_ and `for Azure <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure#supl-client>`_ optionally support building the firmware images with SUPL enabled.
 
 .. note::
 

--- a/docs/firmware/Index.rst
+++ b/docs/firmware/Index.rst
@@ -9,17 +9,17 @@ The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tr
 
    It is compatible with the :ref:`nRF Asset Tracker for AWS <index_aws>`.
 
+   The `firmware GitHub repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_ provides an example for using the application as an out-of-tree development copy, which optionally enables the SUPL client.
+
 .. only:: saga
 
    It is compatible with the :ref:`nRF Asset Tracker for AWS <index_aws>` and the :ref:`nRF Asset Tracker for Azure <index_azure>`.
 
-The `firmware GitHub repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_ provides an example for using the application as an out-of-tree development copy, which optionally enables the SUPL client.
+   The firmware GitHub repositories `for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_ and `for Azure <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_ provide an example for using the application as an out-of-tree development copy, which optionally enables the SUPL client.
 
 .. toctree::
    :titlesonly:
    :caption: Subpages:
 
-   BuildingUsingLocalSystem.rst
-   BuildingUsingDocker.rst
-   BuildingUsingGitHub.rst
-   ../aws/FirmwareContinuousIntegration.rst
+   aws/Index.rst
+   azure/Index.rst

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -26,7 +26,7 @@ To build the the Docker image for this project, run the following commands:
     cd nrf-asset-tracker-firmware-aws
     docker build -t asset-tracker-firmware-docker .
 
-Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf`.
+Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf` file.
 
 Build the project
 *****************

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -14,7 +14,7 @@ If you install `Docker <https://www.docker.com/>`_, it will contain all the depe
 
     See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
 
-The Docker image is not intended to be shared, but to simplify the local building of project.
+The Docker image is not intended to be shared.
 
 The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-aws-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_.
 

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -1,4 +1,4 @@
-.. _firmware-building-docker:
+.. _firmware-aws-building-docker:
 
 Building the project using Docker
 #################################
@@ -8,13 +8,17 @@ Building the project using Docker
    :depth: 2
 
 Building using Docker is the simplest way to build the project on your local system.
-If you install `Docker <https://www.docker.com/>`_ , it will contain all the dependencies in the image, and prevents the need to install them separately in your system.
+If you install `Docker <https://www.docker.com/>`_, it will contain all the dependencies in the image, and prevents the need to install them separately in your system.
+
+.. note::
+
+    See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
 
 The Docker image is not intended to be shared, but to simplify the local building of project.
 
-The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_.
+The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-aws-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_.
 
-To build the project using Docker, run the following commands:
+To build the the Docker image for this project, run the following commands:
 
 .. code-block:: bash
 
@@ -22,17 +26,12 @@ To build the project using Docker, run the following commands:
     cd nrf-asset-tracker-firmware-aws
     docker build -t asset-tracker-firmware-docker .
 
-Edit the value of ``CONFIG_AWS_IOT_BROKER_HOST_NAME`` in :file:`prj.conf` and provide your broker hostname.
-
-.. note::
-
-    See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
+Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf`.
 
 Build the project
 *****************
 
 Build the project for your nRF9160-based device using the specified commands.
-
 
 Thingy:91 (PCA20035)
 ====================

--- a/docs/firmware/aws/BuildingUsingGitHub.rst
+++ b/docs/firmware/aws/BuildingUsingGitHub.rst
@@ -1,4 +1,4 @@
-.. _firmware-building-github-actions:
+.. _firmware-aws-building-github-actions:
 
 Building the project using GitHub actions
 #########################################
@@ -8,10 +8,8 @@ Using the `provided workflow <https://github.com/NordicSemiconductor/asset-track
 
 After you have forked the repository, `enable GitHub Actions <https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions#requesting-to-join-the-limited-public-beta-for-github-actions>`_ and locate the :guilabel:`Actions` tab in your repository, which lists the Action runs.
 
-.. only:: saga
-
-    Configuration for firmware connecting to the nRF Asset Tracker for AWS
-    ======================================================================
+Configuration for firmware connecting to the nRF Asset Tracker for AWS
+======================================================================
 
 Navigate to the settings of the repository and configure a new Secret ``BROKER_HOSTNAME`` and assign the host name of your AWS IoT Core MQTT broker to the secret.
 You can retrieve the host name by using the following command:
@@ -20,4 +18,4 @@ You can retrieve the host name by using the following command:
 
     aws iot describe-endpoint --endpoint-type iot:Data-ATS
 
-Commit a change to your repository, for example, change the MQTT hostname, and the GitHub Action will build the application and attach the HEX files to a release.
+Commit a change to your repository and the GitHub Action will build the application and attach the HEX files to a release.

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -11,6 +11,7 @@ Before building the project using your local system, complete the following step
 
 1. Prepare your system
 #. Clone the project and install the dependencies
+#. Configure the project
 
 Prepare your system
 *******************
@@ -40,7 +41,7 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-Follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf`.
+Follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf` file.
 
 Build the project
 *****************

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -1,0 +1,67 @@
+.. _firmware-aws-building:
+
+Building the project using your local system
+############################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Before building the project using your local system, complete the following steps:
+
+1. Prepare your system
+#. Clone the project and install the dependencies
+
+Prepare your system
+*******************
+
+Follow the `Getting Started Guide <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
+Follow the instructions on `Installing the nRF Connect SDK <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html>`_.
+
+Clone the project and install the dependencies
+**********************************************
+
+Create a folder, for example, ``ncs`` and initialize the project by running the following commands:
+
+.. code-block:: bash
+
+    cd ./ncs
+    sudo pip3 install -U --pre west
+    west init -m https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws \
+        --mr saga firmware
+    west update
+    sudo pip3 install -r zephyr/scripts/requirements.txt
+    sudo pip3 install pc_ble_driver_py
+    sudo pip3 install -r nrf/scripts/requirements.txt
+    sudo pip3 install -r mcuboot/scripts/requirements.txt
+    # this sets $ZEPHYR_TOOLCHAIN_VARIANT and $GNUARMEMB_TOOLCHAIN_PATH
+    source zephyr/zephyr-env.sh
+
+Configure the project
+*********************
+
+Follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and update the :file:`prj.conf`.
+
+Build the project
+*****************
+
+Navigate to the :file:`./ncs/firmware` directory and build the project for your nRF9160-based device.
+
+Thingy:91 (PCA20035)
+====================
+
+.. code-block:: bash
+
+    west build -p always -b thingy91_nrf9160ns
+
+nRF9160 DK (PCA10090)
+=====================
+
+.. code-block:: bash
+
+    west build -p always -b nrf9160_pca10090ns
+
+Location of the HEX file
+************************
+
+The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.hex`.

--- a/docs/firmware/aws/Index.rst
+++ b/docs/firmware/aws/Index.rst
@@ -1,0 +1,19 @@
+.. _firmware-aws-index:
+
+Firmware for the AWS cloud components
+#####################################
+
+The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tracker v2 <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
+
+It is compatible with the :ref:`nRF Asset Tracker for AWS <index_aws>`.
+
+The `firmware GitHub repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_ provides an example for using the application as an out-of-tree development copy, which optionally enables the SUPL client.
+
+.. toctree::
+   :titlesonly:
+   :caption: Subpages:
+
+   BuildingUsingLocalSystem.rst
+   BuildingUsingDocker.rst
+   BuildingUsingGitHub.rst
+   ../../aws/FirmwareContinuousIntegration.rst

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -18,7 +18,7 @@ The Docker image is not intended to be shared.
 
 The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-azure-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_.
 
-To build the the Docker image for this project, run the following commands:
+To build the Docker image for this project, run the following commands:
 
 .. code-block:: bash
 

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -1,0 +1,55 @@
+.. _firmware-azure-building-docker:
+
+Building the project using Docker
+#################################
+
+.. contents::
+   :local:
+   :depth: 2
+
+Building using Docker is the simplest way to build the project on your local system.
+If you install `Docker <https://www.docker.com/>`_, it will contain all the dependencies in the image, and prevents the need to install them separately in your system.
+
+.. note::
+
+    See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
+
+The Docker image is not intended to be shared, but to simplify the local building of project.
+
+The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-azure-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_.
+
+To build the the Docker image for this project, run the following commands:
+
+.. code-block:: bash
+
+    git clone https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure nrf-asset-tracker-firmware-azure
+    cd nrf-asset-tracker-firmware-azure
+    docker build -t asset-tracker-firmware-docker .
+
+Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf`.
+
+Build the project
+*****************
+
+Build the project for your nRF9160-based device using the specified commands.
+
+Thingy:91 (PCA20035)
+====================
+
+.. code-block:: bash
+
+    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b thingy91_nrf9160ns -- -DOVERLAY_CONFIG="overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf"'
+    ls -la build/zephyr/merged.hex
+
+nRF9160 DK (PCA10090)
+=====================
+
+.. code-block:: bash
+
+    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b nrf9160dk_nrf9160ns -- -DOVERLAY_CONFIG="overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf"'
+    ls -la build/zephyr/merged.hex
+
+Location of the HEX file
+************************
+
+The built HEX file will be located in :file:`build/zephyr/merged.hex`.

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -26,7 +26,7 @@ To build the Docker image for this project, run the following commands:
     cd nrf-asset-tracker-firmware-azure
     docker build -t asset-tracker-firmware-docker .
 
-Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf`.
+Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf` file.
 
 Build the project
 *****************

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -14,7 +14,7 @@ If you install `Docker <https://www.docker.com/>`_, it will contain all the depe
 
     See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
 
-The Docker image is not intended to be shared, but to simplify the local building of project.
+The Docker image is not intended to be shared.
 
 The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-azure-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_.
 

--- a/docs/firmware/azure/BuildingUsingGitHub.rst
+++ b/docs/firmware/azure/BuildingUsingGitHub.rst
@@ -11,7 +11,7 @@ After you have forked the repository, `enable GitHub Actions <https://help.githu
 Configuration for firmware connecting to the nRF Asset Tracker for Azure
 ========================================================================
 
-Navigate to the settings of the repository and configure two new Secrets ``AZURE_IOT_HUB_DPS_HOSTNAME``, and ``AZURE_IOT_HUB_DPS_ID_SCOPE`` and assign the DPS host name and DPS ID sceop of your Azure IoT Hub MQTT broker to the secrets.
+Navigate to the settings of the repository and configure two new Secrets ``AZURE_IOT_HUB_DPS_HOSTNAME``, and ``AZURE_IOT_HUB_DPS_ID_SCOPE`` and assign the DPS host name and DPS ID scope of your Azure IoT Hub MQTT broker to the secrets.
 You can retrieve the values for the secrets by using the following command:
 
 .. code-block:: bash

--- a/docs/firmware/azure/BuildingUsingGitHub.rst
+++ b/docs/firmware/azure/BuildingUsingGitHub.rst
@@ -1,6 +1,6 @@
 .. _firmware-azure-building-github-actions:
 
-Building the project using GitHub actions
+Building the project using GitHub Actions
 #########################################
 
 You can use GitHub Actions (which is free for open-source projects) to build the application.

--- a/docs/firmware/azure/BuildingUsingGitHub.rst
+++ b/docs/firmware/azure/BuildingUsingGitHub.rst
@@ -1,0 +1,21 @@
+.. _firmware-azure-building-github-actions:
+
+Building the project using GitHub actions
+#########################################
+
+You can use GitHub Actions (which is free for open-source projects) to build the application.
+Using the `provided workflow <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure/blob/saga/.github/workflows/build-and-release.yaml>`_, you can quickly set up the environment for building your application using a fork.
+
+After you have forked the repository, `enable GitHub Actions <https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions#requesting-to-join-the-limited-public-beta-for-github-actions>`_ and locate the :guilabel:`Actions` tab in your repository, which lists the Action runs.
+
+Configuration for firmware connecting to the nRF Asset Tracker for Azure
+========================================================================
+
+Navigate to the settings of the repository and configure two new Secrets ``AZURE_IOT_HUB_DPS_HOSTNAME``, and ``AZURE_IOT_HUB_DPS_ID_SCOPE`` and assign the DPS host name and DPS ID sceop of your Azure IoT Hub MQTT broker to the secrets.
+You can retrieve the values for the secrets by using the following command:
+
+.. code-block:: bash
+
+    // FIXME: add
+
+Commit a change to your repository and the GitHub Action will build the application and attach the HEX files to a release.

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -16,7 +16,6 @@ Prepare your system
 *******************
 
 Follow the `Getting started documentation <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
-Follow the instructions on `Installing the nRF Connect SDK <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html>`_.
 
 Clone the project and install the dependencies
 **********************************************

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -15,7 +15,7 @@ Before building the project using your local system, complete the following step
 Prepare your system
 *******************
 
-Follow the `Getting Started Guide <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
+Follow the `Getting started documentation <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
 Follow the instructions on `Installing the nRF Connect SDK <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html>`_.
 
 Clone the project and install the dependencies

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -1,4 +1,4 @@
-.. _firmware-building:
+.. _firmware-azure-building:
 
 Building the project using your local system
 ############################################
@@ -27,7 +27,8 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 
     cd ./ncs
     sudo pip3 install -U --pre west
-    west init -m https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws --mr saga
+    west init -m https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure \
+        --mr saga firmware
     west update
     sudo pip3 install -r zephyr/scripts/requirements.txt
     sudo pip3 install pc_ble_driver_py
@@ -35,6 +36,11 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
     sudo pip3 install -r mcuboot/scripts/requirements.txt
     # this sets $ZEPHYR_TOOLCHAIN_VARIANT and $GNUARMEMB_TOOLCHAIN_PATH
     source zephyr/zephyr-env.sh
+
+Configure the project
+*********************
+
+Follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf`.
 
 Build the project
 *****************
@@ -58,4 +64,4 @@ nRF9160 DK (PCA10090)
 Location of the HEX file
 ************************
 
-The built HEX file will be located in :file:`ncs/firmware/build/zephyr/merged.hex`.
+The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.hex`.

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -40,7 +40,7 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-Follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf`.
+Follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and update the :file:`prj.conf` file.
 
 Build the project
 *****************

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -11,6 +11,7 @@ Before building the project using your local system, complete the following step
 
 1. Prepare your system
 #. Clone the project and install the dependencies
+#. Configure the project
 
 Prepare your system
 *******************

--- a/docs/firmware/azure/Index.rst
+++ b/docs/firmware/azure/Index.rst
@@ -1,0 +1,18 @@
+.. _firmware-azure-index:
+
+Firmware for the Azure cloud components
+#######################################
+
+The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tracker v2 <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
+
+It is compatible with the :ref:`nRF Asset Tracker for Azure <index_azure>`.
+
+The `firmware GitHub repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_ provides an example for using the application as an out-of-tree development copy, which optionally enables the SUPL client.
+
+.. toctree::
+   :titlesonly:
+   :caption: Subpages:
+
+   BuildingUsingLocalSystem.rst
+   BuildingUsingDocker.rst
+   BuildingUsingGitHub.rst


### PR DESCRIPTION
The firmware is configured differently per cloud, and also
the out-of-tree reference repo is seperate per supported
cloud provider, so this is reflected in this change.