### PR TITLE
Update thingy programming guide

### DIFF
--- a/docs/devices/FlashingCertificate/Desktop.rst
+++ b/docs/devices/FlashingCertificate/Desktop.rst
@@ -31,7 +31,7 @@ To provision the certificate using LTE Link Monitor, complete the following step
       
       nRF Connect for Desktop - LTE Link Monitor
 
-#. Select the device in the top-left drop-down.
+#. Select the device in the top left drop-down menu.
 
    .. note::
 

--- a/docs/devices/FlashingCertificate/Desktop.rst
+++ b/docs/devices/FlashingCertificate/Desktop.rst
@@ -23,11 +23,7 @@ To provision the certificate using LTE Link Monitor, complete the following step
    *   nRF9160 DK - `91dk_at_host_increased_buf.hex <https://nordicsemiconductor.github.io/at_host-hex/at_host-nrf9160dk_nrf9160ns.hex>`_
 
    For instructions, see :ref:`programming the firmware <program-the-firmware>`.
-
-   .. note::
-
-      Make sure that the selected device is connected directly, not through the debugger.
-
+   
 #. Open nRF Connect for Desktop and launch the LTE Link Monitor application.
 
    .. figure:: ./images/lte-link-monitor-desktop.png
@@ -35,8 +31,14 @@ To provision the certificate using LTE Link Monitor, complete the following step
       
       nRF Connect for Desktop - LTE Link Monitor
 
+#. Select the device in the top-left drop-down.
+
+   .. note::
+
+      Make sure that the selected device is connected directly, not through the debugger.
+
 #. Click :guilabel:`Certificate manager`.
- 
+
    .. figure:: ./images/certificate-manager-desktop.png
       :alt: nRF Connect for Desktop Certificate manager
 

--- a/docs/devices/Index.rst
+++ b/docs/devices/Index.rst
@@ -18,7 +18,7 @@ To connect the device to your account, complete the following steps:
 #. Program the application firmware according to the instructions in the documentation:
 
    * `nRF9160 DK application firmware update <https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_application_firmware.html>`_
-   * `Thingy:91 application firmware update <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_pgming_thingy91_usb.html>`_
+   * `Thingy:91 application firmware update <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_pgm_thingy91_debugprobe.html>`_
 
 
 .. toctree::


### PR DESCRIPTION
This changes the programming instructions so it's clear that the programmer has to be used and changes the link to the Thingy:91 programming instructions to use external debug probe.

Both AT client and Asset Tracker do not support MCUBoot right now.