### PR TITLE
feat(certificates): add note on lifetime

### DIFF
--- a/docs/aws/GettingStarted/DeviceCredentials.rst
+++ b/docs/aws/GettingStarted/DeviceCredentials.rst
@@ -29,6 +29,11 @@ Run the following script to generate and register a CA certificate in your AWS a
     cd ~/nrf-asset-tracker/aws
     node cli create-ca
 
+.. note::
+
+   The default lifetime for CA certificates is 1 year.
+   Run ``node cli create-ca --help`` to learn how to customize the lifetime.
+
 Generate a device certificate
 *****************************
 

--- a/docs/azure/GettingStarted/DeviceCredentials.rst
+++ b/docs/azure/GettingStarted/DeviceCredentials.rst
@@ -27,6 +27,11 @@ To create a CA root certificate and register it with the Azure IoT Device Provis
 
    node cli create-ca-root
 
+.. note::
+
+   The default lifetime for root CA certificates is 1 year.
+   Run ``node cli create-ca-root --help`` to learn how to customize the lifetime.
+
 Do not share the CA root certificate.
 The number of CA root certificates is typically very small, and the minimum number of certificates required is one.
 
@@ -48,6 +53,11 @@ To create a CA intermediate certificate and an enrollment group for it, run the 
 .. code-block:: bash
 
    node cli create-ca-intermediate
+
+.. note::
+
+   The default lifetime for intermediate CA certificates is 1 year.
+   Run ``node cli create-ca-intermediate --help`` to learn how to customize the lifetime.
 
 You can share the CA intermediate certificate with the factory.
 You will have multiple intermediate certificates over time.

--- a/docs/devices/FlashingCertificate/Generate.rst
+++ b/docs/devices/FlashingCertificate/Generate.rst
@@ -24,4 +24,9 @@ Use the IMEI when generating the certificate:
 
     node cli create-device-cert -d "*imei*"
 
+.. note::
+
+    The default lifetime for device certificates is 30 year.
+    Run ``node cli create-device-cert --help`` to learn how to customize the lifetime.
+
 .. body_end

--- a/docs/devices/FlashingCertificate/Generate.rst
+++ b/docs/devices/FlashingCertificate/Generate.rst
@@ -26,7 +26,7 @@ Use the IMEI when generating the certificate:
 
 .. note::
 
-    The default lifetime for device certificates is 30 year.
+    The default lifetime for device certificates is 30 years.
     Run ``node cli create-device-cert --help`` to learn how to customize the lifetime.
 
 .. body_end


### PR DESCRIPTION
This adds a note on the default lifetimes used when generating certificates.