### PR TITLE
fix(diagram): updating the diagram

### DIFF
--- a/docs/project/system-overview-v1.5.x.dot
+++ b/docs/project/system-overview-v1.5.x.dot
@@ -4,15 +4,17 @@ digraph G {
 
     imagepath="/workdir/docs/project"
 
-    bgcolor="#fcfcfc"
+    bgcolor=transparent
 
     compound=true
 
     labelfloat=true
 
     edge [ color="#666666" ]
+
+    splines=false
     
-    celltower [ label="" image="./images/celltower.svg" shape="none" width="1" height="1" imagescale=true ]
+    celltower [ label="" image="./images/celltower.svg" shape="none" width="2" height="1" imagescale=true ]
     satellite [ label="" image="./images/satellite.svg" shape="none" width="1" height="1" imagescale=true ]
     thingy91 [ label="" tooltip="Thingy:91" image="./images/thingy91.svg" shape="none" width="1" height="1" imagescale=true URL="https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-91" ]
 
@@ -29,8 +31,8 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        gellceo [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="Cell Geolocation" ]
-        agpscloud [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="A-GPS" ]
+        gellceo [ shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="Cell Geolocation" ]
+        agpscloud [ shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="A-GPS" ]
     }
 
     subgraph cluster1 {
@@ -38,17 +40,17 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        aws_iot [ shape=component style=filled color="#fe9900" fillcolor="#fe9900" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/aws_iot/README.html" ]
-        asset_tracker_v2 [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" color="#00A9CE" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html" ]
-        agps [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/agps/README.html" ]
+        aws_iot [label="aws iot" width="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/aws_iot/README.html" ]
+        asset_tracker_v2 [label="asset tracker v2" width="1.5" shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" color="#00A9CE" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html" ]
+        agps [ shape=box width="1.5" style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/agps/README.html" ]
     }
 
     subgraph cluster2 {
-        label="Cat Tracker Web Application"
+        label="Cat Tracker web application"
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        aws_api [ label="aws/api" shape=component style=filled color="#fe9900" fillcolor="#fe9900" ]
+        aws_api [ label="aws api" widts="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" ]
         web_app [ label="React SPA" shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js" ]
     }
 
@@ -59,12 +61,12 @@ digraph G {
     aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
     satellite -> thingy91 [ label=GPS ]
-    celltower -> thingy91 [ label="LTE-m/\nNB-IoT" ]
+    celltower -> thingy91 [ label="LTE-M/\nNB-IoT" ]
 
     asset_tracker_v2 -> aws_iot [ dir=back ]
     asset_tracker_v2 -> agps [ dir=back ]
 
-    agpscloud -> nrfcloud [ dir=back headlabel="HTTPs" ltail=cluster4 ]
+    agpscloud -> nrfcloud [ dir=back taillabel="HTTPs" ltail=cluster4 labeldistance="6"]
     gellceo -> nrfcloud [ dir=back ltail=cluster4 ]
     gellceo -> unwiredlabs [ dir=back headlabel="HTTPs" ltail=cluster4 ]
     AWS -> gellceo [ dir=back ltail=cluster0 lhead=cluster4 ]

--- a/docs/project/system-overview-v1.5.x.dot
+++ b/docs/project/system-overview-v1.5.x.dot
@@ -50,7 +50,7 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        aws_api [ label="aws api" widts="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" ]
+        aws_api [ label="aws api" width="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" ]
         web_app [ label="React SPA" shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js" ]
     }
 

--- a/docs/project/system-overview-v1.5.x.dot
+++ b/docs/project/system-overview-v1.5.x.dot
@@ -60,21 +60,20 @@ digraph G {
 
     aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
-    satellite -> thingy91 [ label=GPS ]
-    celltower -> thingy91 [ label="LTE-M/\nNB-IoT" ]
+    satellite -> thingy91 [ label=" GPS " ]
+    celltower -> thingy91 [ label=" LTE-M/\nNB-IoT " ]
 
     asset_tracker_v2 -> aws_iot [ dir=back ]
     asset_tracker_v2 -> agps [ dir=back ]
 
-    agpscloud -> nrfcloud [ dir=back taillabel="HTTPs" ltail=cluster4 labeldistance="6"]
+    agpscloud -> nrfcloud [ dir=back taillabel=" HTTPs " ltail=cluster4 labeldistance="6"]
     gellceo -> nrfcloud [ dir=back ltail=cluster4 ]
-    gellceo -> unwiredlabs [ dir=back headlabel="HTTPs" ltail=cluster4 ]
+    gellceo -> unwiredlabs [ dir=back headlabel=" HTTPs " ltail=cluster4 ]
     AWS -> gellceo [ dir=back ltail=cluster0 lhead=cluster4 ]
 
-    AWS -> aws_api [ label="HTTPs" ltail=cluster0 lhead=cluster2 ]
+    AWS -> aws_api [ label=" HTTPs " ltail=cluster0 lhead=cluster2 ]
 
     aws_api -> web_app
 
     web_app -> phone [ ltail=cluster2 dir=back ]
 }
-

--- a/docs/project/system-overview-v1.5.x.dot
+++ b/docs/project/system-overview-v1.5.x.dot
@@ -58,7 +58,7 @@ digraph G {
         unwiredlabs [ label="" tooltip="Unwired Labs" image="./images/unwiredlabs.png" shape="none" width="1" height="1" imagescale=true URL="https://unwiredlabs.com/" ]
         phone [ label="" image="./images/phone.svg" shape="none" width="1" height="1" imagescale=true ]
 
-    aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
+    aws_iot -> AWS  [ label=" TLS \n +MQTT \n +JSON " dir=back ltail=cluster1 lhead=cluster0 ]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
     satellite -> thingy91 [ label=" GPS " ]
     celltower -> thingy91 [ label=" LTE-M/\nNB-IoT " ]

--- a/docs/project/system-overview.dot
+++ b/docs/project/system-overview.dot
@@ -4,7 +4,7 @@ digraph G {
 
     imagepath="/workdir/docs/project"
 
-    bgcolor="#fcfcfc"
+    bgcolor="#ffffff"
 
     compound=true
 
@@ -12,7 +12,7 @@ digraph G {
 
     edge [ color="#666666" ]
     
-    celltower [ label="" image="./images/celltower.svg" shape="none" width="1" height="1" imagescale=true ]
+    celltower [ label="" image="./images/celltower.svg" shape="none" width="2" height="1" imagescale=true ]
     satellite [ label="" image="./images/satellite.svg" shape="none" width="1" height="1" imagescale=true ]
     thingy91 [ label="" tooltip="Thingy:91" image="./images/thingy91.svg" shape="none" width="1" height="1" imagescale=true URL="https://www.nordicsemi.com/Software-and-tools/Prototyping-platforms/Nordic-Thingy-91" ]
 
@@ -46,7 +46,7 @@ digraph G {
     }
 
     subgraph cluster2 {
-        label="Cat Tracker Web Application"
+        label="Cat Tracker web application"
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
@@ -63,13 +63,13 @@ digraph G {
     azure_iot -> Azure  [ label="TLS+MQTT+JSON" dir=back ltail=cluster1 lhead=cluster0 ]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
     satellite -> thingy91 [ label=GPS ]
-    celltower -> thingy91 [ label="LTE-m/\nNB-IoT" ]
+    celltower -> thingy91 [ label="LTE-M/\nNB-IoT" ]
 
     asset_tracker_v2 -> aws_iot [ dir=back ]
     asset_tracker_v2 -> azure_iot [ dir=back ]
     asset_tracker_v2 -> agps [ dir=back ]
 
-    agpscloud -> nrfcloud [ dir=back headlabel="HTTPs" ltail=cluster4 ]
+    agpscloud -> nrfcloud [ dir=back taillabel="HTTPs" ltail=cluster4 labeldistance="6"]
     gellceo -> nrfcloud [ dir=back ltail=cluster4 ]
     gellceo -> unwiredlabs [ dir=back headlabel="HTTPs" ltail=cluster4 ]
     AWS -> gellceo [ dir=back ltail=cluster0 lhead=cluster4 ]

--- a/docs/project/system-overview.dot
+++ b/docs/project/system-overview.dot
@@ -62,26 +62,25 @@ digraph G {
         phone [ label="" image="./images/phone.svg" shape="none" width="1" height="1" imagescale=true ]
 
     aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
-    azure_iot -> Azure  [ label="TLS+MQTT+JSON" dir=back ltail=cluster1 lhead=cluster0]
+    azure_iot -> Azure  [ label=" TLS+MQTT+JSON " dir=back ltail=cluster1 lhead=cluster0]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
-    satellite -> thingy91 [ label=GPS ]
-    celltower -> thingy91 [ label="LTE-M/\nNB-IoT" ]
+    satellite -> thingy91 [ label=" GPS " ]
+    celltower -> thingy91 [ label=" LTE-M/\nNB-IoT " ]
 
     asset_tracker_v2 -> aws_iot [ dir=back ]
     asset_tracker_v2 -> azure_iot [ dir=back ]
     asset_tracker_v2 -> agps [ dir=back ]
 
-    agpscloud -> nrfcloud [ dir=back taillabel="HTTPs" ltail=cluster4 labeldistance="6"]
+    agpscloud -> nrfcloud [ dir=back taillabel=" HTTPs " ltail=cluster4 labeldistance="6"]
     gellceo -> nrfcloud [ dir=back ltail=cluster4 ]
-    gellceo -> unwiredlabs [ dir=back headlabel="HTTPs" ltail=cluster4 ]
+    gellceo -> unwiredlabs [ dir=back headlabel=" HTTPs " ltail=cluster4 ]
     AWS -> gellceo [ dir=back ltail=cluster0 lhead=cluster4 ]
 
-    AWS -> aws_api [ label="HTTPs" ltail=cluster0 lhead=cluster2 ]
-    Azure -> azure_api [ label="HTTPs" ltail=cluster0 lhead=cluster2 ]
+    AWS -> aws_api [ label=" HTTPs " ltail=cluster0 lhead=cluster2 ]
+    Azure -> azure_api [ label=" HTTPs " ltail=cluster0 lhead=cluster2 ]
 
     aws_api -> web_app
     azure_api -> web_app
 
     web_app -> phone [ ltail=cluster2 dir=back ]
 }
-

--- a/docs/project/system-overview.dot
+++ b/docs/project/system-overview.dot
@@ -61,8 +61,8 @@ digraph G {
         unwiredlabs [ label="" tooltip="Unwired Labs" image="./images/unwiredlabs.png" shape="none" width="1" height="1" imagescale=true URL="https://unwiredlabs.com/" ]
         phone [ label="" image="./images/phone.svg" shape="none" width="1" height="1" imagescale=true ]
 
-    aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
-    azure_iot -> Azure  [ label=" TLS+MQTT+JSON " dir=back ltail=cluster1 lhead=cluster0]
+    aws_iot -> AWS  [ label=" TLS \n +MQTT \n +JSON " dir=back ltail=cluster1 lhead=cluster0 ]
+    azure_iot -> Azure  [ dir=back ltail=cluster1 lhead=cluster0]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
     satellite -> thingy91 [ label=" GPS " ]
     celltower -> thingy91 [ label=" LTE-M/\nNB-IoT " ]

--- a/docs/project/system-overview.dot
+++ b/docs/project/system-overview.dot
@@ -4,13 +4,15 @@ digraph G {
 
     imagepath="/workdir/docs/project"
 
-    bgcolor="#ffffff"
+    bgcolor=transparent
 
     compound=true
 
     labelfloat=true
 
     edge [ color="#666666" ]
+
+    splines=false
     
     celltower [ label="" image="./images/celltower.svg" shape="none" width="2" height="1" imagescale=true ]
     satellite [ label="" image="./images/satellite.svg" shape="none" width="1" height="1" imagescale=true ]
@@ -30,8 +32,8 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        gellceo [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="Cell Geolocation" ]
-        agpscloud [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="A-GPS" ]
+        gellceo [ shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="Cell Geolocation" ]
+        agpscloud [ shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" label="A-GPS" ]
     }
 
     subgraph cluster1 {
@@ -39,10 +41,10 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        aws_iot [ shape=component style=filled color="#fe9900" fillcolor="#fe9900" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/aws_iot/README.html" ]
-        azure_iot [ shape=component style=filled color="#0089d7" fillcolor="#0089d7" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/azure_iot_hub/README.html" ]
-        asset_tracker_v2 [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" color="#00A9CE" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html" ]
-        agps [ shape=component style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/agps/README.html" ]
+        aws_iot [ label="aws iot" width="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/aws_iot/README.html" ]
+        azure_iot [ label="azure iot" width="1.5" shape=box style=filled color="#0089d7" fillcolor="#0089d7" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/azure_iot_hub/README.html" ]
+        asset_tracker_v2 [ label="asset tracker v2" shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" color="#00A9CE" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html" ]
+        agps [ shape=box width ="1.5" style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/agps/README.html" ]
     }
 
     subgraph cluster2 {
@@ -50,8 +52,8 @@ digraph G {
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 
-        aws_api [ label="aws/api" shape=component style=filled color="#fe9900" fillcolor="#fe9900" ]
-        azure_api [ label="azure/api" shape=component style=filled color="#0089d7" fillcolor="#0089d7" ]
+        aws_api [ label="aws api" width="1.5" shape=box style=filled color="#fe9900" fillcolor="#fe9900" ]
+        azure_api [ label="azure api" width="1.5" shape=box style=filled color="#0089d7" fillcolor="#0089d7" ]
         web_app [ label="React SPA" shape=box style=filled color="#00A9CE" fillcolor="#00A9CE" fontcolor="#ffffff" URL="https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js" ]
     }
 
@@ -60,7 +62,7 @@ digraph G {
         phone [ label="" image="./images/phone.svg" shape="none" width="1" height="1" imagescale=true ]
 
     aws_iot -> AWS  [ dir=back ltail=cluster1 lhead=cluster0 ]
-    azure_iot -> Azure  [ label="TLS+MQTT+JSON" dir=back ltail=cluster1 lhead=cluster0 ]
+    azure_iot -> Azure  [ label="TLS+MQTT+JSON" dir=back ltail=cluster1 lhead=cluster0]
     thingy91 -> asset_tracker_v2 [ dir=none lhead=cluster1 ]
     satellite -> thingy91 [ label=GPS ]
     celltower -> thingy91 [ label="LTE-M/\nNB-IoT" ]


### PR DESCRIPTION
The suggested changes for the system overview diagram:

- [x] Fixing the name of LTE-M
- [x] Change width of celltower to make arrow straight
- [x] Change name of Cat Tracker
- [x] Change background color to transparent 
- [x] Make all arrows straight
- [x] Switch from component boxes to basic boxes
- [x] Spacing between arrows and text
- [x] Cut back on the use of symbols

Not possible (see below):

- [ ] Make the length of all arrow the same (especially fix the "cat tracker web application" block)
- [ ] Move the "Optional features" block to be parallel to the Microsoft block
- [ ] Arrows should be snapped to the center of the box
- [ ] Center align the grey blocks
---

- I think the nrf cloud is connected to both "Cell Geolocation" and "A_GPS", while "unwiredlabs" is just connected to "Cell Geolocation". Thats why there are two arrows between those blocks.
