### PR TITLE
build: run sphinx in docker

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           DOCKER_REPO_NAME=`echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]'`
           DOCKER_CHECKSUM=`cat Dockerfile scripts/dot2svg.sh | sha256sum | awk '{ print $1 }' | tr -d '\n'`
-          DOCKER_IMAGE=ghcr.io/${DOCKER_REPO_NAME}/graphviz:${DOCKER_CHECKSUM}
+          DOCKER_IMAGE=ghcr.io/${DOCKER_REPO_NAME}/builder:${DOCKER_CHECKSUM}
           echo "::set-output name=docker_image::${DOCKER_IMAGE}"
           echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> $GITHUB_ENV
 
@@ -52,11 +52,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade --user pip setuptools
-          python3 -m pip install --upgrade --user sphinx recommonmark sphinx_rtd_theme rstcheck
-
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -75,13 +70,9 @@ jobs:
           echo "RELEASE=${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build docs
-        run: |
-          export PATH=$PATH:/home/runner/.local/bin
-          make html
+        run: make html
 
-      - run: |
-          export PATH=$PATH:/home/runner/.local/bin
-          rstcheck -r ./
+      - run: make check
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           DOCKER_REPO_NAME=`echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]'`
           DOCKER_CHECKSUM=`cat Dockerfile scripts/dot2svg.sh | sha256sum | awk '{ print $1 }' | tr -d '\n'`
-          DOCKER_IMAGE=ghcr.io/${DOCKER_REPO_NAME}/graphviz:${DOCKER_CHECKSUM}
+          DOCKER_IMAGE=ghcr.io/${DOCKER_REPO_NAME}/builder:${DOCKER_CHECKSUM}
           echo "::set-output name=docker_image::${DOCKER_IMAGE}"
           echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> $GITHUB_ENV
 
@@ -55,11 +55,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade --user pip setuptools
-          python3 -m pip install --upgrade --user sphinx recommonmark sphinx_rtd_theme
-
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -73,9 +68,7 @@ jobs:
           echo "DOCKER_IMAGE=${{ needs.docker.outputs.docker_image }}" >> $GITHUB_ENV
 
       - name: Build docs
-        run: |
-          export PATH=$PATH:/home/runner/.local/bin
-          make html
+        run: make html
 
       - uses: actions/upload-artifact@v2
         with:
@@ -144,11 +137,6 @@ jobs:
           echo "VERSION=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
           echo "RELEASE=${{ github.sha }}" >> $GITHUB_ENV
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade --user pip setuptools
-          python3 -m pip install --upgrade --user sphinx recommonmark sphinx_rtd_theme
-
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -165,7 +153,6 @@ jobs:
         if: env.RELEASE != '' && env.VERSION != ''
         run: |
           echo "Updating documentation for version ${{ env.VERSION }} release ${{ env.RELEASE }}...";
-          export PATH=$PATH:/home/runner/.local/bin
           # Generate Documentation
           make html
           # Clone gh-pages branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,15 @@ RUN \
     apt-get -y install software-properties-common && \
     add-apt-repository ppa:inkscape.dev/stable && \
     apt-get -y update && \
-    apt-get -y install inkscape
+    apt-get -y install inkscape && \
+    # Install Sphinx and rstcheck
+    apt-get -y install sphinx-common python3-recommonmark python3-sphinx-rtd-theme && \
+    apt-get -y install pip && \
+    pip install rstcheck
 
 COPY ./scripts/dot2svg.sh /bin
+
+ARG RELEASE
+ARG VERSION
+
+COPY ./scripts/sphinx.sh /bin

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: Makefile dotincludes
+.PHONY: Makefile dotincludes check
 
 dotincludes:
 	mkdir -p build/html/docs/project/images
 	cp -v docs/project/images/* build/html/docs/project/images
 
-DOCKER_IMAGE ?= nordicsemiconductor/asset-tracker-cloud-docs/graphviz
+DOCKER_IMAGE ?= nordicsemiconductor/asset-tracker-cloud-docs/builder
 
 docs/project/%.svg: docs/project/%.dot 
 	docker run --rm -v ${PWD}:/workdir ${DOCKER_IMAGE} /bin/dot2svg.sh $< $@
@@ -13,5 +13,7 @@ RELEASE ?= 0.0.0-development
 VERSION ?= saga
 
 html: Makefile dotincludes docs/project/system-overview.svg
-	RELEASE=$(RELEASE) VERSION=$(VERSION) ./scripts/sphinx.sh
-	find docs -type f -name \*.json | xargs -I@ cp -v @ build/html/@
+	docker run --rm -v ${PWD}:/workdir -e RELEASE=$(RELEASE) -e VERSION=$(VERSION) ${DOCKER_IMAGE} /bin/sphinx.sh
+
+check:
+	docker run --rm -v ${PWD}:/workdir -e RELEASE=$(RELEASE) ${DOCKER_IMAGE} rstcheck -r ./build/html

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ Cat Tracker.
 
 > [Read the complete nRF Asset Tracker documentation](https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/).
 
+## Building the docs locally
+
+Build the Docker image:
+
+    docker build -t nordicsemiconductor/asset-tracker-cloud-docs/builder ./
+
+Then build the docs:
+
+    make html
+
+The result will be placed in `./build/html`.
+
+You can use `node-static` to serve it from this folder:
+
+    npx node-static build/html
+
 ## Extending the documentation
 
 The documentation is written in reStructuredText, following the

--- a/scripts/sphinx.sh
+++ b/scripts/sphinx.sh
@@ -11,4 +11,5 @@ if [[ -s "$errlog" ]]; then
     exit 1
 else
     echo "Sphinx build succeeded."
+    find docs -type f -name \*.json | xargs -I@ cp -v @ build/html/@
 fi


### PR DESCRIPTION
This moves the generation of the docs into the Docker
image so Sphinx has not to be installed on the system.