### PR TITLE
feat: use nRF Asset Tracker instead of Cat Tracker

### DIFF
--- a/docs/GettingStarted.rst
+++ b/docs/GettingStarted.rst
@@ -7,10 +7,10 @@ Amazon Web Services (AWS)
 =========================
 
 For installing the nRF Asset Tracker in your AWS account, follow the instructions in :ref:`AWS getting started guide <aws-getting-started>`.
-As next steps, you can deploy the :ref:`Cat Tracker web application <aws-getting-started-app>` and :ref:`connect a real device <connect-using-real-device>`.
+As next steps, you can deploy the :ref:`nRF Asset Tracker web application <aws-getting-started-app>` and :ref:`connect a real device <connect-using-real-device>`.
 
 Microsoft Azure (Azure)
 =======================
 
 For installing the nRF Asset Tracker in your Azure account, follow the instructions in :ref:`Azure getting started guide <azure-getting-started>`.
-As next steps, you can deploy the :ref:`Cat Tracker web application <azure-getting-started-app>` and :ref:`connect a real device <connect-using-real-device>`.
+As next steps, you can deploy the :ref:`nRF Asset Tracker web application <azure-getting-started-app>` and :ref:`connect a real device <connect-using-real-device>`.

--- a/docs/app/Includes.rst
+++ b/docs/app/Includes.rst
@@ -3,7 +3,7 @@
 Clone the project and install the dependencies
 **********************************************
 
-Clone the `Cat Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_ project and install the dependencies:
+Clone the `nRF Asset Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_ project and install the dependencies:
 
 .. parsed-literal::
 

--- a/docs/app/Index.rst
+++ b/docs/app/Index.rst
@@ -1,13 +1,13 @@
 .. _index-cat-tracker-web-app:
 
-Cat Tracker web application
-###########################
+nRF Asset Tracker web application
+#################################
 
-The Cat Tracker web application is a reference single-page application (SPA) developed using `create-react-app <https://github.com/facebook/create-react-app>`_ in
+The nRF Asset Tracker web application is a reference single-page application (SPA) developed using `create-react-app <https://github.com/facebook/create-react-app>`_ in
 `TypeScript <https://www.typescriptlang.org/>`_.
 The `source code for the web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_ is published on GitHub.
 
-To learn more about customizing the Cat Tracker web application, see the `Getting started guide on Create React App <https://create-react-app.dev/docs/getting-started/>`_.
+To learn more about customizing the nRF Asset Tracker web application, see the `Getting started guide on Create React App <https://create-react-app.dev/docs/getting-started/>`_.
 
 The web application offers the following features:
 

--- a/docs/aws/Authentication.rst
+++ b/docs/aws/Authentication.rst
@@ -7,7 +7,7 @@ Authentication
    :local:
    :depth: 2
 
-The :ref:`Cat Tracker web application <aws-getting-started-app>` on AWS connects to the `AWS IoT broker <https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html>`_ using WebSockets, and the authentication is done through `AWS Cognito <https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html>`_.
+The :ref:`nRF Asset Tracker web application <aws-getting-started-app>` on AWS connects to the `AWS IoT broker <https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html>`_ using WebSockets, and the authentication is done through `AWS Cognito <https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html>`_.
 
 See the AWS documentation on `Amazon Cognito identities <https://docs.aws.amazon.com/iot/latest/developerguide/cognito-identities.html>`_ and `Policies for HTTP and WebSocket clients <https://docs.aws.amazon.com/iot/latest/developerguide/pub-sub-policy.html#pub-sub-policy-cognito>`_ for more information.
 

--- a/docs/aws/ContinuousDeployment.rst
+++ b/docs/aws/ContinuousDeployment.rst
@@ -22,9 +22,9 @@ To enable continuous deployment, complete the following steps:
 
 #. Update the `repository.url <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/blob/3ddf0c117de7f22f02df46c3e1ca899915627d46/package.json#L15>`_ in the :file:`package.json` file in your fork. It must point to the repository URL of your fork.
 
-#. Fork the `Cat Tracker web application repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_.
+#. Fork the `nRF Asset Tracker web application repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_.
 
-#. Update the `deploy.webApp.repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/blob/3ddf0c117de7f22f02df46c3e1ca899915627d46/package.json#L144>`_ in the :file:`package.json` file of your nRF Asset Tracker for AWS fork. It must point to the repository URL of your fork of the Cat Tracker web application.
+#. Update the `deploy.webApp.repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/blob/3ddf0c117de7f22f02df46c3e1ca899915627d46/package.json#L144>`_ in the :file:`package.json` file of your nRF Asset Tracker for AWS fork. It must point to the repository URL of your fork of the nRF Asset Tracker web application.
 
 Provide GitHub credentials
 **************************

--- a/docs/aws/Customization/CustomizeWebApp.rst
+++ b/docs/aws/Customization/CustomizeWebApp.rst
@@ -1,14 +1,14 @@
 .. _aws-customization-customize-web-app:
 
-Customize the Cat Tracker web application
-#########################################
+Customize the nRF Asset Tracker web application
+###############################################
 
 The next step is to customize the web application.
-The heart rate readings must be visualized in a new chart on the :ref:`Cat Tracker web application <index-cat-tracker-web-app>`.
+The heart rate readings must be visualized in a new chart on the :ref:`nRF Asset Tracker web application <index-cat-tracker-web-app>`.
 
 To customize the web application, complete the following steps:
 
-1. Navigate to the web application directory created while :ref:`deploying the cat tracker web application to AWS <aws-getting-started-app>`:
+1. Navigate to the web application directory created while :ref:`deploying the nRF Asset Tracker web application to AWS <aws-getting-started-app>`:
 
    .. code-block:: bash
 
@@ -24,7 +24,7 @@ To customize the web application, complete the following steps:
 #. Open the web application by typing `<http://localhost:3000>`_ in the address bar and select the entry for the simulated cat.
 
    .. figure:: ./images/web-app.png
-      :alt: The Cat Tracker web application
+      :alt: The nRF Asset Tracker web application
 
    At this point, you can start modifying the web application and add a new chart section that displays the latest heart rate readings.
 
@@ -51,18 +51,18 @@ To customize the web application, complete the following steps:
 
    To learn more about the syntax, see `Timestream Query language <https://docs.aws.amazon.com/timestream/latest/developerguide/reference.html>`_.
 
-#. After defining the query, add a new chart to the Cat Tracker web application that displays the data in a line chart.
+#. After defining the query, add a new chart to the nRF Asset Tracker web application that displays the data in a line chart.
 
 You can view the code for the necessary changes in the `simulator-ui repository  <https://github.com/acme-cat-tracker/web-app/compare/add-heartrate-monitor-data>`_.
 
 .. figure:: ./images/web-app-with-heart-rate-readings.png
-   :alt: Cat Tracker web application showing the heart rate readings
+   :alt: nRF Asset Tracker web application showing the heart rate readings
 	  
-   Cat Tracker web application showing the heart rate readings
+   nRF Asset Tracker web application showing the heart rate readings
 
-At this point, you have successfully customized the Cat Tracker web application.
+At this point, you have successfully customized the nRF Asset Tracker web application.
 
-If you want to save your changes to the Cat Tracker web application in your own repository, maintain a fork and add the source repository as ``upstream``:
+If you want to save your changes to the nRF Asset Tracker web application in your own repository, maintain a fork and add the source repository as ``upstream``:
 
 .. code-block:: bash
    

--- a/docs/aws/Customization/Index.rst
+++ b/docs/aws/Customization/Index.rst
@@ -3,12 +3,12 @@
 Customization of the nRF Asset Tracker
 ######################################
 
-This section walks you through the customization of the nRF Asset Tracker for your own product. It shows how to visualize additional sensor data on the :ref:`Cat Tracker web application <index-cat-tracker-web-app>`.
+This section walks you through the customization of the nRF Asset Tracker for your own product. It shows how to visualize additional sensor data on the :ref:`nRF Asset Tracker web application <index-cat-tracker-web-app>`.
 
 Through the example, the following changes are made:
 
 1. :ref:`Device Simulator UI <simulator-aws>` is modified to generate the heart rate sensor data.
-#. :ref:`Cat Tracker web application <index-cat-tracker-web-app>` is modified to display the sensor data.
+#. :ref:`nRF Asset Tracker web application <index-cat-tracker-web-app>` is modified to display the sensor data.
 
 The following video and table show the customization steps and the associated timestamps:
 

--- a/docs/aws/GettingStarted/Webapp.rst
+++ b/docs/aws/GettingStarted/Webapp.rst
@@ -1,7 +1,7 @@
 .. _aws-getting-started-app:
 
-Deploy the Cat Tracker web application
-######################################
+Deploy the nRF Asset Tracker web application
+############################################
 
 .. contents::
    :local:

--- a/docs/aws/Upgrading.rst
+++ b/docs/aws/Upgrading.rst
@@ -10,7 +10,7 @@ Upgrading an existing installation
 Before starting an upgrade, read the release notes:
 
 * `Release notes for the nRF Asset Tracker for AWS <https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/releases>`_
-* `Release notes for the Cat Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js/releases>`_
+* `Release notes for the nRF Asset Tracker web application <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js/releases>`_
 
 Pay close attention to Breaking changes.
 
@@ -26,8 +26,8 @@ If you already have an installation and you want to upgrade to the latest releas
        npx tsc
        npx cdk deploy '*' 
 
-Upgrading an existing Cat Tracker web application installation
-**************************************************************
+Upgrading an existing nRF Asset Tracker web application installation
+********************************************************************
 
 If you already have an installation and you want to upgrade to the latest release, pull in the changes and perform the update:
 
@@ -36,4 +36,4 @@ If you already have an installation and you want to upgrade to the latest releas
        git pull
        npm ci
 
-To publish the upgrade to AWS, perform the steps for the initial installation as described in :ref:`Deploying the Cat Tracker web application <aws-getting-started-app>`.
+To publish the upgrade to AWS, perform the steps for the initial installation as described in :ref:`Deploying the nRF Asset Tracker web application <aws-getting-started-app>`.

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -20,9 +20,9 @@ To enable continuous deployment, complete the following steps:
 
 1. Fork the `nRF Asset Tracker for Azure repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js>`_.
 
-#. Fork the `Cat Tracker web application repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_.
+#. Fork the `nRF Asset Tracker web application repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_.
 
-#. Update the `deploy.webApp.repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/blob/fd3777cde331286faf10e481bdf1a30327882008/package.json#L111>`_ in the :file:`package.json` file of your nRF Asset Tracker for Azure fork. It must point to the repository URL of your fork of the Cat Tracker web application.
+#. Update the `deploy.webApp.repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/blob/fd3777cde331286faf10e481bdf1a30327882008/package.json#L111>`_ in the :file:`package.json` file of your nRF Asset Tracker for Azure fork. It must point to the repository URL of your fork of the nRF Asset Tracker web application.
 
 Acquire credentials for GitHub Actions
 **************************************

--- a/docs/azure/GettingStarted/Webapp.rst
+++ b/docs/azure/GettingStarted/Webapp.rst
@@ -1,7 +1,7 @@
 .. _azure-getting-started-app:
 
-Deploy the Cat Tracker web application
-######################################
+Deploy the nRF Asset Tracker web application
+############################################
 
 .. contents::
    :local:

--- a/docs/device-simulator-ui/Simulator.rst
+++ b/docs/device-simulator-ui/Simulator.rst
@@ -7,7 +7,7 @@ Connect using the simulator
     :local:
     :depth: 2
 
-The CLI provides a software implementation of Cat Tracker for testing purposes.
+The CLI provides a software implementation of a nRF9160-based asset tracker for testing purposes.
 It allows the verification of the cloud configuration.
 This feature is also used for testing the nRF Asset Tracker using continuous integration.
 

--- a/docs/guides/CellGeolocations.rst
+++ b/docs/guides/CellGeolocations.rst
@@ -6,7 +6,7 @@ Cell geolocations
    :depth: 2
 
 Locating a device is an important aspect of any IoT solution.
-It is one of the primary functions in the case of an asset tracker (like the Cat Tracker).
+It is one of the primary functions in the case of an asset tracker.
 Sometimes, acquiring a GNSS fix is not possible, for example, when the device is indoors.
 In such case, other data can be used to approximately calculate the location of the device.
 If the device has a cellular connection, the ID of the cells with which the device modem communicates can be used to calculate its location.
@@ -15,8 +15,8 @@ The approximate location of the device is then used by the GNSS module to speed 
 
 However, smartphones are powerful devices and there is a concrete need to have the location information on the device instantly (for example, for showing the location of the user in a navigation application while the device is indoors).
 Smartphones have location-dependent features, while most of the IoT devices do not have such features.
-For example, the Cat Tracker has no feature that depends on a location, it only reports the location to the cloud backend.
-In this case, only the mobile app that visualizes the location of the Cat Tracker requires the location of the device.
+For example, the nRF Asset Tracker has no feature that depends on a location, it only reports the location to the cloud backend.
+In this case, only the mobile app that visualizes the location of the nRF Asset Tracker requires the location of the device.
 
 .. note::
 
@@ -25,7 +25,7 @@ In this case, only the mobile app that visualizes the location of the Cat Tracke
 Assisted GPS (A-GPS)
 ********************
 
-The only location-dependent feature on the Cat Tracker is A-GPS, which speeds up the time to acquire the first GNSS fix (seconds instead of minutes). 
+The only location-dependent feature of the nRF Asset Tracker is A-GPS, which speeds up the time to acquire the first GNSS fix (seconds instead of minutes). 
 Complex location triangulation based on mobile network cells or Wi-Fi MAC addresses is not required.
 It is sufficient to have an up-to-date `GPS almanac <https://en.wikipedia.org/wiki/GPS_signals#Almanac>`_ and an approximate location, which can be derived from the mobile network operator's country code.
 This data enables the GNSS module to calculate a GPS fix quickly.

--- a/docs/project/CorePrinciples.rst
+++ b/docs/project/CorePrinciples.rst
@@ -6,7 +6,7 @@ Core principles
 The nRF Asset Tracker is built on the following principles:
 
 Teach by showing
-  All the examples are designed to solve a concrete use case (a Cat Tracker) instead of providing generic or abstract solutions.
+  All the examples are designed to solve a concrete use case (an asset tracker) instead of providing generic or abstract solutions.
   It is not a framework, but a real application.
 
 Err on the side of security

--- a/docs/project/system-overview.dot
+++ b/docs/project/system-overview.dot
@@ -49,7 +49,7 @@ digraph G {
     }
 
     subgraph cluster2 {
-        label="Cat Tracker web application"
+        label="nRF Asset Tracker web application"
         labelloc=b
         fontsize=16
         bgcolor="#D9E1E2" color="#cccccc" 

--- a/index.rst
+++ b/index.rst
@@ -3,7 +3,7 @@
 nRF Asset Tracker
 #################
 
-The nRF Asset Tracker is an application that aims to provide a concrete end-to-end example for an ultra-low power cellular IoT product in the asset tracker space, specifically a Cat Tracker.
+The nRF Asset Tracker is an application that aims to provide a concrete end-to-end example for an ultra-low power cellular IoT product in the asset tracker space.
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
The nRF Asset Tracker supports more use cases
than only tracking cats, so this change reflects
that.