### PR TITLE
docs: added missing keyword 'start' to run UI

### DIFF
--- a/docs/device-simulator-ui/Simulator.rst
+++ b/docs/device-simulator-ui/Simulator.rst
@@ -66,7 +66,7 @@ To run the device simulator UI, use the following command:
 
 .. code-block:: bash
 
-    npm run start
+    npm start
 
 After executing the above command, copy the endpoint printed above (for example, ``http://localhost:25336``) and use it in the simulator UI.
 

--- a/docs/device-simulator-ui/Simulator.rst
+++ b/docs/device-simulator-ui/Simulator.rst
@@ -66,7 +66,7 @@ To run the device simulator UI, use the following command:
 
 .. code-block:: bash
 
-    npm run
+    npm run start
 
 After executing the above command, copy the endpoint printed above (for example, ``http://localhost:25336``) and use it in the simulator UI.
 


### PR DESCRIPTION
## Proposed changes
Updated docs, added missing keyword 'start' to run device simulator UI