### PR TITLE
fix(aws): document nRF Cloud team ID

### DIFF
--- a/docs/aws/nRFCloudLocationServices.rst
+++ b/docs/aws/nRFCloudLocationServices.rst
@@ -3,6 +3,18 @@
 nRF Cloud Location Services
 ###########################
 
+Prerequisites
+*************
+
+Any nRF Cloud Location Service requires the configuration of your team ID.
+
+Use the following command to configure your team ID:
+
+.. parsed-literal::
+    :class: highlight
+
+    node cli configure thirdParty nrfcloud teamId *your team ID*
+
 Cell Location Service
 *********************
 

--- a/docs/aws/nRFCloudLocationServices.rst
+++ b/docs/aws/nRFCloudLocationServices.rst
@@ -6,7 +6,7 @@ nRF Cloud Location Services
 Prerequisites
 *************
 
-Any nRF Cloud Location Service requires the configuration of your team ID.
+To use any nRF Cloud Location Service, you need to configure your team ID.
 
 Use the following command to configure your team ID:
 

--- a/docs/aws/nRFCloudLocationServices.rst
+++ b/docs/aws/nRFCloudLocationServices.rst
@@ -8,7 +8,7 @@ Prerequisites
 
 To use any nRF Cloud Location Service, you need to configure your team ID.
 
-Use the following command to configure your team ID:
+Run the following command to configure your team ID:
 
 .. parsed-literal::
     :class: highlight


### PR DESCRIPTION
The team ID has to be set in order to be able
to use any Location Service.