### PR TITLE
link fix: new links to upgrade and update instructions

### DIFF
--- a/docs/devices/Index.rst
+++ b/docs/devices/Index.rst
@@ -9,16 +9,16 @@ To connect the device to your account, complete the following steps:
 
 1. Upgrade the modem firmware according to the instructions in the documentation:
 
-   * `nRF9160 DK modem upgrade <https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_modem_firmware.html>`_
-   * `Thingy:91 modem upgrade <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_updating_modem_thingy91_intro.html>`_
+   * `nRF9160 DK modem upgrade <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf9160_gs.html#updating-the-modem-firmware>`_
+   * `Thingy:91 modem upgrade <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thingy91_gsg.html#updating-firmware>`_
 
 #. :ref:`Provision the certificate <devices-provisioning-certificate>`.
 
    .. _program-the-firmware:
 #. Program the application firmware according to the instructions in the documentation:
 
-   * `nRF9160 DK application firmware update <https://infocenter.nordicsemi.com/topic/ug_nrf91_dk_gsg/UG/nrf91_DK_gsg/updating_application_firmware.html>`_
-   * `Thingy:91 application firmware update <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_pgm_thingy91_debugprobe.html>`_
+   * `nRF9160 DK application firmware update <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_nrf9160_gs.html#updating-the-application-firmware>`_
+   * `Thingy:91 application firmware update <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thingy91_gsg.html#updating-firmware>`_
 
 
 .. toctree::


### PR DESCRIPTION
In Connect using a real device page, fixed
the links to point to NCS docs instead of
infocenter. This was due to the doc transfer.

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>