### PR TITLE
Azure: use OIDC for GitHub Actions

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -2,6 +2,9 @@ name: PR checks
 
 on: pull_request
 
+permissions:
+  packages: write
+
 jobs:
   docker:
     name: Prepare Docker image
@@ -16,7 +19,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine Docker image name and tag
         id: docker-image-tag
@@ -57,7 +60,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull Docker image
         run: |

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -6,6 +6,9 @@ on:
       - saga
       - "v*"
 
+permissions:
+  packages: write
+
 jobs:
   docker:
     name: Prepare Docker image
@@ -20,7 +23,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine Docker image name and tag
         id: docker-image-tag
@@ -60,7 +63,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull Docker image
         run: |
@@ -142,7 +145,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull Docker image
         run: |

--- a/docs/aws/ContinuousIntegration/WebApp.rst
+++ b/docs/aws/ContinuousIntegration/WebApp.rst
@@ -96,7 +96,7 @@ You need to configure AWS credentials as `GitHub environment secrets <https://do
     - ``AWS_SECRET_ACCESS_KEY``
     - ``WEBAPP_STACK_NAME``
 
-  - Set the secrets using the GitHub CLI:
+  - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_ (before this, create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository):
 
     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the
     environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):

--- a/docs/aws/ContinuousIntegration/WebApp.rst
+++ b/docs/aws/ContinuousIntegration/WebApp.rst
@@ -21,7 +21,7 @@ Running end-to-end tests during development
 The end-to-end tests run against an instance of the :ref:`nRF Asset Tracker for AWS <index_aws>`.
 
 Use either the credentials you created, :ref:`when setting up the solution <aws-getting-started>`, or enable the Web App CI feature and use the dedicated credentials created for this task.
-The latter option is the recommended approach since it limits the permissions to only the ones needed. 
+The latter option is the recommended approach since it limits the permissions to only the ones needed.
 You can also use the credentials to :ref:`run the end-to-end tests on GitHub Actions <aws-continuous-integration-web-app-github>`.
 
 1. Add the following environment variables to your :file:`.envrc` file:
@@ -88,18 +88,16 @@ You need to configure AWS credentials as `GitHub environment secrets <https://do
 
   - Set the secrets using the GitHub UI:
 
-    You can set the secrets through the GitHub UI (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first).
-    Set these secrets:
-    
+    Set the following `secrets <https://docs.github.com/en/rest/reference/actions#secrets>`_ to an `environment <https://docs.github.com/en/actions/reference/environments#creating-an-environment>`_ called ``production`` in your fork of the nRF Asset Tracker for AWS:
+
     - ``AWS_REGION``
     - ``AWS_ACCESS_KEY_ID``
     - ``AWS_SECRET_ACCESS_KEY``
     - ``WEBAPP_STACK_NAME``
 
-  - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_ (before this, create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository):
+  - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_:
 
-    Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the
-    environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
+    You can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `deployment environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/aws/ContinuousIntegration/WebApp.rst
+++ b/docs/aws/ContinuousIntegration/WebApp.rst
@@ -99,7 +99,7 @@ You need to configure AWS credentials as `GitHub environment secrets <https://do
   - Set the secrets using the GitHub CLI:
 
     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the
-    environment settings from above:
+    environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -50,7 +50,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      * ``AZURE_CLIENT_ID`` - Store the application (client) ID of the service principal app registration created in step in the above step.
      * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in the previous step.
-     * ``AZURE_SUBSCRIPTION_ID`` - Store the ID of the subscription which contains the nRF Asset Tracker resources.
+     * ``AZURE_SUBSCRIPTION_ID`` - Store the ID of the subscription containing the nRF Asset Tracker resources.
 
      Set the following following values from your :file:`.envrc` file as secrets as well:
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -65,7 +65,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_:
 
-     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
+     You can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -60,7 +60,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
      * ``B2C_TENANT``
      * ``APP_REG_CLIENT_ID``
 
-     If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key as a secret as well:
+     If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
      * ``UNWIRED_LABS_API_KEY``
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -64,7 +64,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      * ``UNWIRED_LABS_API_KEY``
 
-   - Set the secrets using the GitHub CLI:
+   - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_:
 
      Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -46,7 +46,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    - Set the secrets using the GitHub UI:
 
-     Set the following `secrets <https://docs.github.com/en/rest/reference/actions#secrets>`_ through the GitHub UI to an `environment <https://docs.github.com/en/actions/reference/environments#creating-an-environment>`_ called ``production`` in your fork of the nRF Asset Tracker for Azure:
+     Set the following `secrets <https://docs.github.com/en/rest/reference/actions#secrets>`_ to an `environment <https://docs.github.com/en/actions/reference/environments#creating-an-environment>`_ called ``production`` in your fork of the nRF Asset Tracker for Azure:
 
      * ``AZURE_CLIENT_ID`` - Store the application (client) ID of the service principal app registration created in step in the above step.
      * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in step in the above step.

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -89,7 +89,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}
 
-#. Grant the application created in step 1 "Key Vault Secrets Officer" to the KeyVault:
+#. Grant the application created in Step 1 "Key Vault Secrets Officer" rights to the KeyVault:
 
    .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -32,6 +32,16 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 1. Follow the instructions to `Configure a service principal with a Federated Credential to use OIDC based authentication <https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication>`_.
    Use ``https://nrfassettracker.invalid/cd`` as the name.
 
+   From the command line this can be achieved using:
+
+   .. code-block:: bash
+
+      az ad app create --display-name 'https://nrfassettracker.invalid/cd'
+      export APPLICATION_OBJECT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .id' | tr -d '\n'`
+      az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body '{"name":"GitHub Actions","issuer":"https://token.actions.githubusercontent.com","subject":"repo:NordicSemiconductor/asset-tracker-cloud-azure-js:environment:production","description":"Allow GitHub Actions to modify Azure resources","audiences":["api://AzureADTokenExchange"]}' 
+
+   Make sure to use the organization and repository name of your fork instead of ``NordicSemiconductor/asset-tracker-cloud-azure-js`` in the command above.
+
 #. Set the secrets:
 
    - Set the secrets using the GitHub UI:
@@ -71,12 +81,12 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
        gh secret set B2C_TENANT --env production --body "${B2C_TENANT}"
        gh secret set APP_REG_CLIENT_ID --env production --body "${APP_REG_CLIENT_ID}"
 
-#. Grant the application created in step 1 Contributor permissions for your resource group:
+#. Grant the application created in step 1 Owner permissions for your resource group:
 
    .. code-block:: bash
 
       export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId' | tr -d '\n'`
-      az role assignment create --role Contributor \
+      az role assignment create --role Owner \
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -48,7 +48,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      Set the following `secrets <https://docs.github.com/en/rest/reference/actions#secrets>`_ to an `environment <https://docs.github.com/en/actions/reference/environments#creating-an-environment>`_ called ``production`` in your fork of the nRF Asset Tracker for Azure:
 
-     * ``AZURE_CLIENT_ID`` - Store the application (client) ID of the service principal app registration created in step in the above step.
+     * ``AZURE_CLIENT_ID`` - Store the application (client) ID of the service principal app registration created in the previous step.
      * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in the previous step.
      * ``AZURE_SUBSCRIPTION_ID`` - Store the ID of the subscription containing the nRF Asset Tracker resources.
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -64,10 +64,9 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
-
    - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_:
 
-     You can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
+     You can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `deployment environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -29,6 +29,8 @@ Authenticate GitHub Actions against Azure using OpenID Connect
 
 To allow the continuous deployment GitHub Action workflow to authenticate against Azure with short-lived credentials using a service principal, complete the following steps:
 
+.. _azure-continuous-deployment-configure-service-principal:
+
 1. Follow the instructions to `Configure a service principal with a Federated Credential to use OIDC based authentication <https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication>`_.
    Use ``https://nrfassettracker.invalid/cd`` as the name.
 
@@ -80,7 +82,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
        gh secret set B2C_TENANT --env production --body "${B2C_TENANT}"
        gh secret set APP_REG_CLIENT_ID --env production --body "${APP_REG_CLIENT_ID}"
 
-#. Grant the application created in step 1 Owner permissions for your resource group:
+#. Grant the application created in :ref:`step 1 <azure-continuous-deployment-configure-service-principal>` Owner permissions for your resource group:
 
    .. code-block:: bash
 
@@ -89,7 +91,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}
 
-#. Grant the application created in Step 1 "Key Vault Secrets Officer" rights to the KeyVault:
+#. Grant the application created in :ref:`step 1 <azure-continuous-deployment-configure-service-principal>` "Key Vault Secrets Officer" rights to the KeyVault:
 
    .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -32,7 +32,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 1. Follow the instructions to `Configure a service principal with a Federated Credential to use OIDC based authentication <https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication>`_.
    Use ``https://nrfassettracker.invalid/cd`` as the name.
 
-   From the command line this can be achieved using:
+   On the command line, use the following commands:
 
    .. code-block:: bash
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -49,7 +49,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
      Set the following `secrets <https://docs.github.com/en/rest/reference/actions#secrets>`_ to an `environment <https://docs.github.com/en/actions/reference/environments#creating-an-environment>`_ called ``production`` in your fork of the nRF Asset Tracker for Azure:
 
      * ``AZURE_CLIENT_ID`` - Store the application (client) ID of the service principal app registration created in step in the above step.
-     * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in step in the above step.
+     * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in the previous step.
      * ``AZURE_SUBSCRIPTION_ID`` - Store the ID of the subscription which contains the nRF Asset Tracker resources.
 
      Set the following following values from your :file:`.envrc` file as secrets as well:

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -62,7 +62,6 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
-     * ``UNWIRED_LABS_API_KEY``
 
    - Alternatively, set the secrets using the `GitHub CLI <https://cli.github.com/>`_:
 

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -56,12 +56,12 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    - Set the secrets using the GitHub CLI:
 
-     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above:
+     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``production`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 
-       export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId'`
-       export AZURE_TENANT_ID=`az ad sp show --id ${AZURE_CLIENT_ID} | jq -r '.appOwnerOrganizationId'`
+       export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId' | tr -d '\n'`
+       export AZURE_TENANT_ID=`az ad sp show --id ${AZURE_CLIENT_ID} | jq -r '.appOwnerOrganizationId' | tr -d '\n'`
        gh secret set AZURE_CLIENT_ID --env production --body "${AZURE_CLIENT_ID}"
        gh secret set AZURE_TENANT_ID --env production --body "${AZURE_TENANT_ID}"
        gh secret set AZURE_SUBSCRIPTION_ID --env production --body "${SUBSCRIPTION_ID}"
@@ -75,7 +75,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    .. code-block:: bash
 
-      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId'`
+      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId' | tr -d '\n'`
       az role assignment create --role Contributor \
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}
@@ -84,6 +84,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    .. code-block:: bash
 
+      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .appId' | tr -d '\n'`
       az role assignment create --role "Key Vault Secrets Officer" \
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettracker}

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -52,7 +52,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
      * ``AZURE_TENANT_ID`` - Store the directory (tenant) ID of the service principal app registration created in the previous step.
      * ``AZURE_SUBSCRIPTION_ID`` - Store the ID of the subscription containing the nRF Asset Tracker resources.
 
-     Set the following following values from your :file:`.envrc` file as secrets as well:
+     Set also the following values from your :file:`.envrc` file as secrets:
 
      * ``RESOURCE_GROUP``
      * ``LOCATION``

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -118,4 +118,4 @@ You can see a workflow run of the Continuous Deployment action:
 More information
 ****************
 
-You can read more about how GitHub Actions uses OIDC on `About security hardening with OpenID Connect <https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect>`_ in the GitHub Actions documentation.
+For more details about how GitHub Actions uses OIDC, read `About security hardening with OpenID Connect <https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect>`_ in the GitHub Actions documentation.

--- a/docs/azure/ContinuousDeployment.rst
+++ b/docs/azure/ContinuousDeployment.rst
@@ -40,7 +40,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
       export APPLICATION_OBJECT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/cd") | .id' | tr -d '\n'`
       az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body '{"name":"GitHub Actions","issuer":"https://token.actions.githubusercontent.com","subject":"repo:NordicSemiconductor/asset-tracker-cloud-azure-js:environment:production","description":"Allow GitHub Actions to modify Azure resources","audiences":["api://AzureADTokenExchange"]}' 
 
-   Make sure to use the organization and repository name of your fork instead of ``NordicSemiconductor/asset-tracker-cloud-azure-js`` in the command above.
+   Use the organization and repository name of your fork instead of ``NordicSemiconductor/asset-tracker-cloud-azure-js`` in the command.
 
 #. Set the secrets:
 

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -266,7 +266,7 @@ To run the end-to-end tests against the solution during development, run the fol
 
 .. note::
 
-   Azure functions allow only one Client ID and Issuer URL in the Active Directory authentication configuration. So, you cannot interact with this instance from the end-to-end tests and the web application since the user flow name differs (``B2C_1_developer`` for end-to-end tests and ``B2C_1_signup_signin`` for the web application) and it is part of the Issuer URL (for example, ``https://${TENANT_DOMAIN}.b2clogin.com/${TENANT_DOMAIN}.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_developer``).
+   Azure functions allow only one Client ID and Issuer URL in the Active Directory authentication configuration. You cannot interact with this instance from the end-to-end tests and the web application, because the user flow names are different (``B2C_1_developer`` for end-to-end tests and ``B2C_1_signup_signin`` for the web application) and it is part of the Issuer URL (for example, ``https://${TENANT_DOMAIN}.b2clogin.com/${TENANT_DOMAIN}.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_developer``).
 
 More information
 ****************

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -198,7 +198,6 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
-     * ``UNWIRED_LABS_API_KEY``
 
    - Set the secrets using the GitHub CLI:
 

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -194,35 +194,35 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
    - Set the secrets using the GitHub CLI:
 
-     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above:
+     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``ci`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 
-       export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId'`
-       export AZURE_TENANT_ID=`az ad sp show --id ${AZURE_CLIENT_ID} | jq -r '.appOwnerOrganizationId'`
-       gh secret set AZURE_CLIENT_ID --env production --body "${AZURE_CLIENT_ID}"
-       gh secret set AZURE_TENANT_ID --env production --body "${AZURE_TENANT_ID}"
-       gh secret set AZURE_SUBSCRIPTION_ID --env production --body "${SUBSCRIPTION_ID}"
-       gh secret set RESOURCE_GROUP --env production --body "${RESOURCE_GROUP}"
-       gh secret set LOCATION --env production --body "${LOCATION}"
-       gh secret set APP_NAME --env production --body "${APP_NAME}"
-       gh secret set B2C_TENANT --env production --body "${B2C_TENANT}"
-       gh secret set APP_REG_CLIENT_ID --env production --body "${APP_REG_CLIENT_ID}"
+       export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId' | tr -d '\n'`
+       export AZURE_TENANT_ID=`az ad sp show --id ${AZURE_CLIENT_ID} | jq -r '.appOwnerOrganizationId' | tr -d '\n'`
+       gh secret set AZURE_CLIENT_ID --env ci --body "${AZURE_CLIENT_ID}"
+       gh secret set AZURE_TENANT_ID --env ci --body "${AZURE_TENANT_ID}"
+       gh secret set AZURE_SUBSCRIPTION_ID --env ci --body "${SUBSCRIPTION_ID}"
+       gh secret set RESOURCE_GROUP --env ci --body "${RESOURCE_GROUP}"
+       gh secret set LOCATION --env ci --body "${LOCATION}"
+       gh secret set APP_NAME --env ci --body "${APP_NAME}"
+       gh secret set B2C_TENANT --env ci --body "${B2C_TENANT}"
+       gh secret set APP_REG_CLIENT_ID --env ci --body "${APP_REG_CLIENT_ID}"
 
-#. Grant the application created in step 1 Contributor permissions for your resource group:
+#. Grant the application created in step 1 Contributor permissions for your subscription:
 
    .. code-block:: bash
 
-      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId'`
+      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId' | tr -d '\n'`
       az role assignment create --role Contributor \
          --assignee ${AZURE_CLIENT_ID} \
-         --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettrackerci}
+         --scope /subscriptions/${SUBSCRIPTION_ID}
 
 #. Grant the application created in step 1 "Key Vault Secrets Officer" to the KeyVault:
 
    .. code-block:: bash
 
-      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId'`
+      export AZURE_CLIENT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .appId' | tr -d '\n'`
       az role assignment create --role "Key Vault Secrets Officer" \
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettrackerci}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettrackerci}

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -165,6 +165,8 @@ Set up continuous integration on GitHub
 
 To allow the continuous deployment GitHub Action workflow to authenticate against Azure with short-lived credentials using a service principal, complete the following steps:
 
+.. _azure-continuous-integration-configure-service-principal:
+
 1. Follow the instructions to `Configure a service principal with a Federated Credential to use OIDC based authentication <https://github.com/Azure/login#configure-a-service-principal-with-a-federated-credential-to-use-oidc-based-authentication>`_.
    Use ``https://nrfassettracker.invalid/ci`` as the name.
 
@@ -216,7 +218,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
        gh secret set B2C_TENANT --env ci --body "${B2C_TENANT}"
        gh secret set APP_REG_CLIENT_ID --env ci --body "${APP_REG_CLIENT_ID}"
 
-#. Grant the application created in step 1 Owner permissions for your subscription:
+#. Grant the application created in :ref:`step 1 <azure-continuous-integration-configure-service-principal>` Owner permissions for your subscription:
 
    .. code-block:: bash
 
@@ -225,7 +227,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
          --assignee ${AZURE_CLIENT_ID} \
          --scope /subscriptions/${SUBSCRIPTION_ID}
 
-#. Grant the application created in step 1 "Key Vault Secrets Officer" to the KeyVault:
+#. Grant the application created in :ref:`step 1 <azure-continuous-integration-configure-service-principal>` "Key Vault Secrets Officer" to the KeyVault:
 
    .. code-block:: bash
 

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -264,7 +264,8 @@ To run the end-to-end tests against the solution during development, run the fol
 
 .. note::
 
-   Azure functions allow only one Client ID and Issuer URL in the Active Directory authentication configuration. You cannot interact with this instance from the end-to-end tests and the web application, because the user flow names are different (``B2C_1_developer`` for end-to-end tests and ``B2C_1_signup_signin`` for the web application) and it is part of the Issuer URL (for example, ``https://${TENANT_DOMAIN}.b2clogin.com/${TENANT_DOMAIN}.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_developer``).
+   Azure functions allow only one Client ID and Issuer URL in the Active Directory authentication configuration. 
+   You cannot interact with this instance from the end-to-end tests and the web application, because the user flow names are different (``B2C_1_developer`` for end-to-end tests and ``B2C_1_signup_signin`` for the web application) and it is part of the Issuer URL (for example, ``https://${TENANT_DOMAIN}.b2clogin.com/${TENANT_DOMAIN}.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1_developer``).
 
 More information
 ****************

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -157,9 +157,7 @@ Fork the nRF Asset Tracker repositories
 To enable continuous deployment, complete the following steps:
 
 1. Fork the `nRF Asset Tracker for Azure repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js>`_.
-
 #. Fork the `nRF Asset Tracker web application repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-app-js>`_.
-
 #. Update the `deploy.webApp.repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/blob/fd3777cde331286faf10e481bdf1a30327882008/package.json#L111>`_ in the :file:`package.json` file of your nRF Asset Tracker for Azure fork. It must point to the repository URL of your fork of the nRF Asset Tracker web application.
 
 Set up continuous integration on GitHub

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -200,10 +200,9 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
-
    - Set the secrets using the GitHub CLI:
 
-     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``ci`` `environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
+     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``ci`` `deployment environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -196,7 +196,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
      * ``B2C_TENANT``
      * ``APP_REG_CLIENT_ID``
 
-     If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key as a secret as well:
+     If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
      * ``UNWIRED_LABS_API_KEY``
 

--- a/docs/azure/ContinuousIntegration.rst
+++ b/docs/azure/ContinuousIntegration.rst
@@ -52,7 +52,7 @@ To create the resource group for the CI resources, complete the following steps:
 
    .. code-block:: bash
 
-       az account set --subscription $SUBSCRIPTION_ID 
+       az account set --subscription $SUBSCRIPTION_ID
        # Verify that it is set to default
        az account list --output table
 
@@ -62,7 +62,7 @@ To create the resource group for the CI resources, complete the following steps:
    .. code-block:: bash
 
       export RESOURCE_GROUP="nrfassettrackerci"
-    
+
 #. Choose a name for the solution and export it as ``APP_NAME``.
    Use a short name (not more than 16 characters) composed of numbers and lowercase letters only.
    In this example, ``nrfassettrackerci`` is used as the application name.
@@ -95,13 +95,13 @@ Create a secondary tenant (Azure Active Directory B2C)
    #. Follow the instructions in the `tutorial for setting up a resource owner password credentials flow in Azure Active Directory B2C <https://docs.microsoft.com/en-us/azure/active-directory-b2c/add-ropc-policy?tabs=app-reg-ga&pivots=b2c-user-flow#register-an-application>`_ and register an application.
       Make sure to set the following parameters:
 
-      * Set the :guilabel:`Supported account types` to :guilabel:`All users`     
-      * Update the Azure Active Directory app manifest and allow implicit grant flow for OAuth2: 
-        
+      * Set the :guilabel:`Supported account types` to :guilabel:`All users`
+      * Update the Azure Active Directory app manifest and allow implicit grant flow for OAuth2:
+
         .. code-block:: json
 
            {"oauth2AllowImplicitFlow": true}
-   
+
 #. Export the initial domain name that you used:
 
    .. parsed-literal::
@@ -127,21 +127,21 @@ Create a secondary tenant (Azure Active Directory B2C)
    a. In the left menu, under :guilabel:`Manage`, select :guilabel:`API permissions`. Add the permission to manage user accounts (:guilabel:`Microsoft Graph` -> :guilabel:`Application permission` -> :guilabel:`User.ReadWrite.All`).
 
 #. Grant the B2C directory API permissions for the function app:
-   
+
    a. Click :guilabel:`Expose an API` and  set the :guilabel:`Application ID URI` field to ``api``.
-   
+
    #. Click :guilabel:`+ Add a scope` and create a new scope with the following values and click :guilabel:`Add a scope`:
-      
+
       * Scope name - ``nrfassettracker.admin``
       * Admin consent display name - Administrator access to the nRF Asset Tracker API
       * Admin consent description - Allows administrator access to all resources exposed through the nRF Asset Tracker API
 
    #. Click :guilabel:`API permissions` and then click :guilabel:`+ Add a permission`. Under :guilabel:`My APIs`, select the app registration.
-   
+
    #. Enable the ``nrfassettracker.admin`` permission and click :guilabel:`Add permission`.
-   
+
 #. Click :guilabel:`Grant admin consent for <your B2C directory>`.
-   
+
 #. Create a new client secret for the App registration (for example, ``12OzW72ie-U.vlmzik-eO5gX.x26jLTI6U``) and note it down.
 
    .. parsed-literal::
@@ -176,7 +176,7 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
       az ad app create --display-name 'https://nrfassettracker.invalid/ci'
       export APPLICATION_OBJECT_ID=`az ad app list | jq -r '.[] | select(.displayName=="https://nrfassettracker.invalid/ci") | .id' | tr -d '\n'`
-      az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body '{"name":"GitHub Actions","issuer":"https://token.actions.githubusercontent.com","subject":"repo:NordicSemiconductor/asset-tracker-cloud-azure-js:environment:ci","description":"Allow GitHub Actions to modify Azure resources","audiences":["api://AzureADTokenExchange"]}' 
+      az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body '{"name":"GitHub Actions","issuer":"https://token.actions.githubusercontent.com","subject":"repo:NordicSemiconductor/asset-tracker-cloud-azure-js:environment:ci","description":"Allow GitHub Actions to modify Azure resources","audiences":["api://AzureADTokenExchange"]}'
 
    Make sure to use the organization and repository name of your fork instead of ``NordicSemiconductor/asset-tracker-cloud-azure-js`` in the command above.
 
@@ -200,9 +200,9 @@ To allow the continuous deployment GitHub Action workflow to authenticate agains
 
      If you have enabled the :ref:`azure-unwired-labs-cell-geolocation`, add your API key ``UNWIRED_LABS_API_KEY`` as a secret as well.
 
-   - Set the secrets using the GitHub CLI:
+   - Alternatively, set the secrets using the GitHub CLI:
 
-     Alternatively, you can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``ci`` `deployment environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
+     You can use the `GitHub CLI <https://cli.github.com/>`_  with the environment settings from above (make sure to create the ``ci`` `deployment environment <https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment>`_ in your repository first):
 
     .. code-block:: bash
 

--- a/docs/azure/UnwiredLabsCellGeolocation.rst
+++ b/docs/azure/UnwiredLabsCellGeolocation.rst
@@ -32,7 +32,9 @@ Store the API key into the key vault as follows:
 
    # Grant the current user set permission to the key vault secrets
    USER_OBJECT_ID=`az ad signed-in-user show --query objectId -o tsv`
-   az keyvault set-policy --name ${keyVaultName} --object-id ${USER_OBJECT_ID} --secret-permissions set
+   az role assignment create --role "Key Vault Secrets Officer" \
+      --assignee-object-id ${USER_OBJECT_ID} \
+      --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettracker}
    
    # Store the API key
    az keyvault secret set --vault-name ${APP_NAME:-nrfassettracker} \\

--- a/docs/azure/nRFCloudLocationServices.rst
+++ b/docs/azure/nRFCloudLocationServices.rst
@@ -37,7 +37,9 @@ Store the service key into the key vault as follows:
 
    # Grant the current user set permission to the key vault secrets
    USER_OBJECT_ID=`az ad signed-in-user show --query objectId -o tsv`
-   az keyvault set-policy --name ${keyVaultName} --object-id ${USER_OBJECT_ID} --secret-permissions set
+   az role assignment create --role "Key Vault Secrets Officer" \
+       --assignee-object-id ${USER_OBJECT_ID} \
+       --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettracker}
     
    # Store the API key
    az keyvault secret set --vault-name ${APP_NAME:-nrfassettracker} \\
@@ -77,7 +79,9 @@ Store the service key into the key vault as follows:
 
    # Grant the current user set permission to the key vault secrets
    USER_OBJECT_ID=`az ad signed-in-user show --query objectId -o tsv`
-   az keyvault set-policy --name ${keyVaultName} --object-id ${USER_OBJECT_ID} --secret-permissions set
+   az role assignment create --role "Key Vault Secrets Officer" \
+      --assignee-object-id ${USER_OBJECT_ID} \
+      --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettracker}
 
    # Store the API key
    az keyvault secret set --vault-name ${APP_NAME:-nrfassettracker} \\
@@ -117,7 +121,9 @@ Store the service key into the key vault as follows:
 
    # Grant the current user set permission to the key vault secrets
    USER_OBJECT_ID=`az ad signed-in-user show --query objectId -o tsv`
-   az keyvault set-policy --name ${keyVaultName} --object-id ${USER_OBJECT_ID} --secret-permissions set
+   az role assignment create --role "Key Vault Secrets Officer" \
+      --assignee-object-id ${USER_OBJECT_ID} \
+      --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP:-nrfassettracker}/providers/Microsoft.KeyVault/vaults/${APP_NAME:-nrfassettracker}
 
    # Store the API key
    az keyvault secret set --vault-name ${APP_NAME:-nrfassettracker} \\


### PR DESCRIPTION
nRF Asset Tracker for Azure now uses OpenID Connect to authenticate GitHub Actions against Azure using short-lived credentials.

See 
- https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/pull/369
- https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js/pull/370