### PR TITLE
fix: use nrf-docker image

### DIFF
--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -14,20 +14,16 @@ If you install `Docker <https://www.docker.com/>`_, it will contain all the depe
 
     See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
 
-The Docker image is not intended to be shared.
-
 The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-aws-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws>`_.
 
-To build the the Docker image for this project, run the following commands:
+To clone the firmware repository, run the following command:
 
 .. parsed-literal::
 
     git clone --branch |version| --single-branch \\
-      https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws nrf-asset-tracker-firmware-aws
-    cd nrf-asset-tracker-firmware-aws
-    docker build -t asset-tracker-firmware-docker .
+      https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws firmware
 
-Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and add your settings to the :file:`firmware.conf` file.
+Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and add your settings to the :file:`firmware.conf` file in the ``firmware`` folder.
 
 Build the project
 *****************
@@ -39,7 +35,7 @@ Thingy:91 (PCA20035)
 
 .. code-block:: bash
 
-    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b thingy91_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-debug.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf"'
+    docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b thingy91_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-debug.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf"'
     ls -la build/zephyr/merged.hex
 
 nRF9160 DK (PCA10090)
@@ -47,7 +43,7 @@ nRF9160 DK (PCA10090)
 
 .. code-block:: bash
 
-    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-debug.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf"'
+    docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-aws.conf;overlay-debug.conf;asset-tracker-cloud-firmware-aws.conf;firmware.conf"'
     ls -la build/zephyr/merged.hex
 
 Location of the HEX file

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -14,20 +14,16 @@ If you install `Docker <https://www.docker.com/>`_, it will contain all the depe
 
     See `Building nRF Connect SDK applications with Docker <https://devzone.nordicsemi.com/nordic/nrf-connect-sdk-guides/b/getting-started/posts/build-ncs-application-firmware-images-using-docker>`_ for more information.
 
-The Docker image is not intended to be shared.
-
 The Docker image is also used to automate the building of HEX files :ref:`using GitHub Actions <firmware-azure-building-github-actions>`, which is used to :ref:`continuously deliver the firmware builds <guides-automate-hexfile-building>` in the `out-of-tree example repository <https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure>`_.
 
-To build the Docker image for this project, run the following commands:
+To clone the firmware repository, run the following command:
 
 .. parsed-literal::
 
     git clone --branch |version| --single-branch \\
-      https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure nrf-asset-tracker-firmware-azure
-    cd nrf-asset-tracker-firmware-azure
-    docker build -t asset-tracker-firmware-docker .
+      https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure firmware
 
-Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and add your settings to the :file:`firmware.conf` file.
+Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and add your settings to the :file:`firmware.conf` file in the ``firmware`` folder.
 
 Build the project
 *****************
@@ -39,7 +35,7 @@ Thingy:91 (PCA20035)
 
 .. code-block:: bash
 
-    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b thingy91_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-azure.conf;overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf;firmware.conf"'
+    docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b thingy91_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-azure.conf;overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf;firmware.conf"'
     ls -la build/zephyr/merged.hex
 
 nRF9160 DK (PCA10090)
@@ -47,7 +43,7 @@ nRF9160 DK (PCA10090)
 
 .. code-block:: bash
 
-    docker run --rm -v ${PWD}:/workdir/ncs/firmware asset-tracker-firmware-docker /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-azure.conf;overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf;firmware.conf"'
+    docker run --rm -v ${PWD}:/workdir/project nordicplayground/nrfconnect-sdk:main /bin/bash -c 'cd firmware && west init -l && west update --narrow -o=--depth=1 && west build -p always -b nrf9160dk_nrf9160_ns -- -DOVERLAY_CONFIG="overlay-azure.conf;overlay-debug.conf;asset-tracker-cloud-firmware-azure.conf;firmware.conf"'
     ls -la build/zephyr/merged.hex
 
 Location of the HEX file


### PR DESCRIPTION
The intermediate docker image is no longer needed.