### PR TITLE
Update 'Configure firmware' step

### DIFF
--- a/docs/aws/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/aws/GettingStarted/FirmwareConfiguration.rst
@@ -5,7 +5,7 @@ Configure the firmware
 
 To configure the :ref:`firmware <firmware-aws-index>`, complete the following mandatory steps:
 
-1. Create the file :file:`firmware.conf` to be used for your configuration overrides.
+1. Create the file :file:`firmware.conf` in the ``~/nrf-asset-tracker`` folder for your configuration overrides.
 
 #. Run the following command to print the MQTT endpoint to which your devices will connect:
 

--- a/docs/aws/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/aws/GettingStarted/FirmwareConfiguration.rst
@@ -11,6 +11,8 @@ To configure the :ref:`firmware <firmware-aws-index>`, complete the following ma
 
    .. code-block:: bash
 
+      # ~/nrf-asset-tracker/aws
+      
       node cli info -o mqttEndpoint
 
 #. Add the ``CONFIG_AWS_IOT_BROKER_HOST_NAME`` setting to the :file:`firmware.conf` file, using the endpoint value from the previous step as the value:

--- a/docs/aws/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/aws/GettingStarted/FirmwareConfiguration.rst
@@ -5,7 +5,7 @@ Configure the firmware
 
 To configure the :ref:`firmware <firmware-aws-index>`, complete the following mandatory steps:
 
-1. Create the file :file:`firmware.conf` in the ``~/nrf-asset-tracker`` folder for your configuration overrides.
+1. Create the file :file:`firmware.conf` in the :file:`~/nrf-asset-tracker` folder for your configuration overrides.
 
 #. Run the following command to print the MQTT endpoint to which your devices will connect:
 

--- a/docs/azure/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/azure/GettingStarted/FirmwareConfiguration.rst
@@ -11,6 +11,8 @@ To configure the :ref:`firmware <firmware-azure-index>`, complete the following 
 
    .. code-block:: bash
 
+      # ~/nrf-asset-tracker/aws
+
       node cli info -o iotHubDpsIdScope
 
 #. Add the ``CONFIG_AZURE_IOT_HUB_DPS_ID_SCOPE`` setting to the :file:`firmware.conf` file, using the Azure IoT DPS ID scope value from the previous step as the value:

--- a/docs/azure/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/azure/GettingStarted/FirmwareConfiguration.rst
@@ -5,7 +5,7 @@ Configure the firmware
 
 To configure the :ref:`firmware <firmware-azure-index>`, complete the following mandatory steps:
 
-1. Create the file :file:`firmware.conf` in the ``~/nrf-asset-tracker`` folder for your configuration overrides.
+1. Create the file :file:`firmware.conf` in the :file:`~/nrf-asset-tracker` folder for your configuration overrides.
 
 #. Run the following command to print the Azure IoT DPS ID scope, which your devices use during device provisioning:
 

--- a/docs/azure/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/azure/GettingStarted/FirmwareConfiguration.rst
@@ -5,7 +5,7 @@ Configure the firmware
 
 To configure the :ref:`firmware <firmware-azure-index>`, complete the following mandatory steps:
 
-1. Create the file :file:`firmware.conf` to be used for your configuration overrides.
+1. Create the file :file:`firmware.conf` in the ``~/nrf-asset-tracker`` folder for your configuration overrides.
 
 #. Run the following command to print the Azure IoT DPS ID scope, which your devices use during device provisioning:
 

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -25,7 +25,15 @@ To clone the firmware repository, run the following command:
     git clone --branch |version| --single-branch \\
       https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws firmware
 
-Then, follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and add your settings to the :file:`firmware.conf` file in the ``firmware`` folder.
+If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <aws-firmware-configuration>`.
+
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
+
+.. code-block:: bash
+
+    # ~/nrf-asset-tracker
+
+    mv ~/nrf-asset-tracker/firmware.conf ~/nrf-asset-tracker/firmware/
 
 Build the project
 *****************
@@ -52,3 +60,8 @@ Location of the HEX file
 ************************
 
 The built HEX file will be located in :file:`build/zephyr/merged.hex`.
+
+Device credentials
+******************
+
+For the device to be able to connect to the nRF Asset Tracker for AWS, now :ref:`create device credentials <aws-device-credentials>`.

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -25,7 +25,7 @@ To clone the firmware repository, run the following command:
     git clone --branch |version| --single-branch \\
       https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws firmware
 
-If you have not configured the firmware yet, follow the :ref:` instructions for configuring the firmware <aws-firmware-configuration>`.
+If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <aws-firmware-configuration>`.
 
 Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
 

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -27,7 +27,7 @@ To clone the firmware repository, run the following command:
 
 If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <aws-firmware-configuration>`.
 
-Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into the :file:`~/nrf-asset-tracker/firmware` folder.
 
 .. code-block:: bash
 

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -25,7 +25,7 @@ To clone the firmware repository, run the following command:
     git clone --branch |version| --single-branch \\
       https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-aws firmware
 
-If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <aws-firmware-configuration>`.
+If you have not configured the firmware yet, follow the :ref:` instructions for configuring the firmware <aws-firmware-configuration>`.
 
 Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
 

--- a/docs/firmware/aws/BuildingUsingDocker.rst
+++ b/docs/firmware/aws/BuildingUsingDocker.rst
@@ -64,4 +64,4 @@ The built HEX file will be located in :file:`build/zephyr/merged.hex`.
 Device credentials
 ******************
 
-For the device to be able to connect to the nRF Asset Tracker for AWS, now :ref:`create device credentials <aws-device-credentials>`.
+For the device to be able to connect to the nRF Asset Tracker for AWS, you must :ref:`create device credentials <aws-device-credentials>`.

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -17,7 +17,6 @@ Prepare your system
 *******************
 
 Follow the `Getting Started Guide <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
-Follow the instructions on `Installing the nRF Connect SDK <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html>`_.
 
 Clone the project and install the dependencies
 **********************************************
@@ -25,6 +24,8 @@ Clone the project and install the dependencies
 Create a folder, for example, ``ncs`` and initialize the project by running the following commands:
 
 .. code-block:: bash
+
+    # ~/nrf-asset-tracker
 
     cd ./ncs
     sudo pip3 install -U --pre west
@@ -41,7 +42,15 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-Follow the :ref:`configuration instructions for the firmware <aws-firmware-configuration>` and add your settings to the :file:`firmware.conf` file.
+If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <aws-firmware-configuration>`.
+
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
+
+.. code-block:: bash
+
+    # ~/nrf-asset-tracker
+
+    mv ~/nrf-asset-tracker/firmware.conf ~/nrf-asset-tracker/ncs/firmware/
 
 Build the project
 *****************
@@ -66,3 +75,8 @@ Location of the HEX file
 ************************
 
 The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.hex`.
+
+Device credentials
+******************
+
+For the device to be able to connect to the nRF Asset Tracker for AWS, now :ref:`create device credentials <aws-device-credentials>`.

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -79,4 +79,4 @@ The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.
 Device credentials
 ******************
 
-For the device to be able to connect to the nRF Asset Tracker for AWS, now :ref:`create device credentials <aws-device-credentials>`.
+For the device to be able to connect to the nRF Asset Tracker for AWS, you must :ref:`create device credentials <aws-device-credentials>`.

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -42,7 +42,7 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <aws-firmware-configuration>`.
+If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <aws-firmware-configuration>`.
 
 Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
 

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -44,7 +44,7 @@ Configure the project
 
 If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <aws-firmware-configuration>`.
 
-Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into the :file:`~/nrf-asset-tracker/ncs/firmware` folder.
 
 .. code-block:: bash
 

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -25,7 +25,7 @@ To clone the firmware repository, run the following command:
     git clone --branch |version| --single-branch \\
       https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure firmware
 
-If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <azure-firmware-configuration>`.
+If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <azure-firmware-configuration>`.
 
 Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
 

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -25,7 +25,15 @@ To clone the firmware repository, run the following command:
     git clone --branch |version| --single-branch \\
       https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure firmware
 
-Then, follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and add your settings to the :file:`firmware.conf` file in the ``firmware`` folder.
+If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <azure-firmware-configuration>`.
+
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
+
+.. code-block:: bash
+
+    # ~/nrf-asset-tracker
+
+    mv ~/nrf-asset-tracker/firmware.conf ~/nrf-asset-tracker/firmware/
 
 Build the project
 *****************
@@ -52,3 +60,8 @@ Location of the HEX file
 ************************
 
 The built HEX file will be located in :file:`build/zephyr/merged.hex`.
+
+Device credentials
+******************
+
+For the device to be able to connect to the nRF Asset Tracker for Azure, now :ref:`create device credentials <azure-device-credentials>`.

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -64,4 +64,4 @@ The built HEX file will be located in :file:`build/zephyr/merged.hex`.
 Device credentials
 ******************
 
-For the device to be able to connect to the nRF Asset Tracker for Azure, now :ref:`create device credentials <azure-device-credentials>`.
+For the device to be able to connect to the nRF Asset Tracker for Azure, you must :ref:`create device credentials <azure-device-credentials>`.

--- a/docs/firmware/azure/BuildingUsingDocker.rst
+++ b/docs/firmware/azure/BuildingUsingDocker.rst
@@ -27,7 +27,7 @@ To clone the firmware repository, run the following command:
 
 If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <azure-firmware-configuration>`.
 
-Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/firmware``.
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into the :file:`~/nrf-asset-tracker/firmware` folder.
 
 .. code-block:: bash
 

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -42,7 +42,7 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <azure-firmware-configuration>`.
+If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <azure-firmware-configuration>`.
 
 Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
 

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -25,6 +25,8 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 
 .. code-block:: bash
 
+    # ~/nrf-asset-tracker
+
     cd ./ncs
     sudo pip3 install -U --pre west
     west init -m https://github.com/NordicSemiconductor/asset-tracker-cloud-firmware-azure \
@@ -40,7 +42,15 @@ Create a folder, for example, ``ncs`` and initialize the project by running the 
 Configure the project
 *********************
 
-Follow the :ref:`configuration instructions for the firmware <azure-firmware-configuration>` and add your settings to the :file:`firmware.conf` file.
+If you haven't configured the firmware yet, follow the :ref:`configure the firmware instructions <azure-firmware-configuration>`.
+
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
+
+.. code-block:: bash
+
+    # ~/nrf-asset-tracker
+
+    mv ~/nrf-asset-tracker/firmware.conf ~/nrf-asset-tracker/ncs/firmware/
 
 Build the project
 *****************
@@ -65,3 +75,8 @@ Location of the HEX file
 ************************
 
 The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.hex`.
+
+Device credentials
+******************
+
+For the device to be able to connect to the nRF Asset Tracker for Azure, now :ref:`create device credentials <azure-device-credentials>`.

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -79,4 +79,4 @@ The built HEX file will be located in :file:`./ncs/firmware/build/zephyr/merged.
 Device credentials
 ******************
 
-For the device to be able to connect to the nRF Asset Tracker for Azure, now :ref:`create device credentials <azure-device-credentials>`.
+For the device to be able to connect to the nRF Asset Tracker for Azure, you must :ref:`create device credentials <azure-device-credentials>`.

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -44,7 +44,7 @@ Configure the project
 
 If you have not configured the firmware yet, follow the :ref:`instructions for configuring the firmware <azure-firmware-configuration>`.
 
-Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into ``~/nrf-asset-tracker/ncs/firmware``.
+Then, move the :file:`~/nrf-asset-tracker/firmware.conf` file into the :file:`~/nrf-asset-tracker/ncs/firmware` folder.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Right now, there are some confusions about where some steps should occur. 

#478 implement some changes to make visible the working directory where the commands should be executed and this PR add fixes to detail where to locate files and specify clarification to avoid circular confusion between `Configure the firmware` step and `build firmware` options.

**Circular confusion:**
If you are following the documentation (https://nordicsemiconductor.github.io/asset-tracker-cloud-docs/saga/docs/aws/GettingStarted/Index.html), the `Configure the firmware` step has an issue, because at some point you will need to compile the firmware and to do that you have some options, however that will take you to another page and if after finish that process you click `next`, it will show you other building options but not to the `Create device credentials`.

This is the solution I'am proposing, however I'm open to discuss it and find new ways. 