### PR TITLE
fix(gcp): remove Google IoT Core

### DIFF
--- a/docs/cloud-protocol/TransportAndData.rst
+++ b/docs/cloud-protocol/TransportAndData.rst
@@ -21,7 +21,7 @@ MQTT as the transport protocol
 
 The nRF Asset Tracker uses MQTT to connect the device to the cloud provider.
 MQTT is the default protocol used for IoT in the cloud solutions of the various cloud providers.
-This example currently focuses on AWS, Microsoft Azure, and Google Cloud.
+This example currently focuses on AWS, and Microsoft Azure.
 
 .. _json-format:
 

--- a/docs/cloud-protocol/TransportAndData.rst
+++ b/docs/cloud-protocol/TransportAndData.rst
@@ -21,7 +21,7 @@ MQTT as the transport protocol
 
 The nRF Asset Tracker uses MQTT to connect the device to the cloud provider.
 MQTT is the default protocol used for IoT in the cloud solutions of the various cloud providers.
-This example currently focuses on AWS, and Microsoft Azure.
+This example currently focuses on AWS and Microsoft Azure.
 
 .. _json-format:
 

--- a/docs/guides/CloudDifferences.rst
+++ b/docs/guides/CloudDifferences.rst
@@ -9,34 +9,6 @@ Cloud differences
 
 This guide describes the key differences between the reference AWS implementation and other IoT implementations by different cloud providers.
 
-Google Cloud Platform (GCP)
-***************************
-
-Authentication
-==============
-
-Devices connect to the broker host using TLS 1.2, but authenticate against MQTT using a username (any) and a JWT token, signed with the device key.
-This means that you must provision the devices with the `TLS Root Certificates <https://cloud.google.com/iot/docs/how-tos/mqtt-bridge#using_a_long-term_mqtt_domain>`_ and a device-specific keypair.
-
-Digital twin
-============
-
-GCP has Configuration (AWS: desired) and State (AWS: reported).
-
-Devices receive their configuration by subscribing to the ``/devices/${deviceId}/config`` topic.
-On successful subscription, the devices receive the configuration on this topic.
-If the configuration is changed, the updated configuration will be published to the topic.
-There is no delta.
-
-Devices publish their state to ``/devices/${deviceId}/state`` topic.
-The devices must always publish the entire state.
-There is no native support for partial updates.
-
-WebSockets
-==========
-
-The IoT Core does not support WebSocket connection, which is used in the app to get notifications about changes on the device state in real time.
-
 Microsoft Azure
 ***************
 

--- a/docs/guides/FourKindsOfData.rst
+++ b/docs/guides/FourKindsOfData.rst
@@ -152,8 +152,6 @@ Even though the concrete implementation differs for each cloud provider, the gen
 |                                     |                         |                  |           |                   |
 |                                     | ``reported``            | ``desired``      |           |                   |
 +-------------------------------------+-------------------------+------------------+-----------+-------------------+
-| :abbr:`GCP (Google Cloud Platform)` | `Device configuration`_ | `Device state`_  | MQTT      |                   |
-+-------------------------------------+-------------------------+------------------+-----------+-------------------+
 | :abbr:`Azure (Microsoft Azure)`     | `Device twins`_         | `Device twins`_  | MQTT      | `MQTT and HTTPS`_ |
 |                                     |                         |                  |           |                   |
 |                                     | ``reported``            | ``desired``      |           |                   |
@@ -161,7 +159,5 @@ Even though the concrete implementation differs for each cloud provider, the gen
 
 .. _Device shadow: https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html
 .. _Jobs: https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html
-.. _Device configuration: https://cloud.google.com/iot/docs/concepts/devices#device_configuration>
-.. _Device state: https://cloud.google.com/iot/docs/concepts/devices#device_state
 .. _Device twins: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins
 .. _MQTT and HTTPS: https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-firmware-update

--- a/docs/project/SupportedCloudProviders.rst
+++ b/docs/project/SupportedCloudProviders.rst
@@ -46,4 +46,4 @@ These survey results can have an influence on the cloud provider selection.
 
 A value of ``100%`` in the chart corresponds to the majority of answers given for a specific cloud provider in the survey, while the rest of the percentage values for the different cloud providers (with less answers) are given relatively to the majority of answers for a specific cloud provider per year.
 
-¹ As of August 16th 2022, Google has announce the retirement of Google IoT Core by August 16th 2023.
+¹ As of August 16th 2022, Google has announced the retirement of Google IoT Core by August 16th 2023.

--- a/docs/project/SupportedCloudProviders.rst
+++ b/docs/project/SupportedCloudProviders.rst
@@ -12,13 +12,13 @@ Hence, in this project, the best practices of the respective cloud vendor for bu
 
 See the below table for a list of supported cloud providers:
 
-+-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-|                       | Amazon Web Services                                                                              | Microsoft Azure                                                                                  | Google Cloud                                                |
-+=======================+==================================================================================================+==================================================================================================+=============================================================+
-| LTE-M: TCP and MQTT   | :ref:`Feature complete <aws-getting-started>`                                                    | :ref:`Feature complete <azure-getting-started>`                                                  | `On hold <https://github.com/bifravst/bifravst/issues/25>`_ |
-+-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-| NB-IoT: UDP and LwM2M | `In consideration <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/issues/338>`_ | `In consideration <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/issues/338>`_ |                                                             |
-+-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------------------------------------------------------+
++-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+
+|                       | Amazon Web Services                                                                              | Microsoft Azure                                                                                  |
++=======================+==================================================================================================+==================================================================================================+
+| LTE-M: TCP and MQTT   | :ref:`Feature complete <aws-getting-started>`                                                    | :ref:`Feature complete <azure-getting-started>`                                                  |
++-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+
+| NB-IoT: UDP and LwM2M | `In consideration <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/issues/338>`_ | `In consideration <https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/issues/338>`_ |
++-----------------------+--------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+
 
 In the case of cloud providers without native UDP and LwM2M support, the option of using a bridge such as `Eclipse Californium <https://github.com/eclipse/californium>`_, was evaluated.
 For more information, see `Leshan LwM2M AWS IoT Gateway <https://github.com/coderbyheart/leshan-aws>`_.
@@ -33,7 +33,7 @@ The following table provides a comparison between the results of the IoT cloud v
 +=================+========================+========================+========================+=================================================================================================================================+
 | AWS             | 1\. 100%               | 1\. 100%               | 1\. 100%               | 1\. 100%                                                                                                                        |
 +-----------------+------------------------+------------------------+------------------------+---------------------------------------------------------------------------------------------------------------------------------+
-| Google          | 2\. 54% ▼              | 2\. 68% ▼              | 2\. 79%                | 3\. 73%                                                                                                                         |
+| Google¹         | 2\. 54% ▼              | 2\. 68% ▼              | 2\. 79%                | 3\. 73%                                                                                                                         |
 +-----------------+------------------------+------------------------+------------------------+---------------------------------------------------------------------------------------------------------------------------------+
 | Azure           | 3\. 50% ▼              | 3\. 66%                | 3\. 66%                | 2\. 84%                                                                                                                         |
 +-----------------+------------------------+------------------------+------------------------+---------------------------------------------------------------------------------------------------------------------------------+
@@ -45,3 +45,5 @@ The following table provides a comparison between the results of the IoT cloud v
 These survey results can have an influence on the cloud provider selection.
 
 A value of ``100%`` in the chart corresponds to the majority of answers given for a specific cloud provider in the survey, while the rest of the percentage values for the different cloud providers (with less answers) are given relatively to the majority of answers for a specific cloud provider per year.
+
+¹ As of August 16th 2022, Google has announce the retirement of Google IoT Core by August 16th 2023.


### PR DESCRIPTION
As of August 16th 2022, Google has announced the retirement of Google IoT Core by August 16th 2023.

![Screenshot_20220816_124344](https://user-images.githubusercontent.com/188915/184862499-bf2b1947-28dc-4289-81f9-6c4365633371.png)

