### PR TITLE
feat(cfg): extend accelerometer config

### DIFF
--- a/docs/aws/desired-cfg.json
+++ b/docs/aws/desired-cfg.json
@@ -5,6 +5,8 @@
     "actwt": 60,
     "mvres": 60,
     "mvt": 3600,
-    "acct": 1.2
+    "accath": 10.0,
+    "accith": 5.0,
+    "accito": 1.0
   }
 }

--- a/docs/cloud-protocol/cfg.schema.json
+++ b/docs/cloud-protocol/cfg.schema.json
@@ -37,12 +37,26 @@
       "maximum": 2147483647,
       "examples": [60]
     },
-    "acct": {
-      "description": "Accelerometer threshold in m/s²: Minimal absolute value for an accelerometer reading to be considered movement.",
+    "accath": {
+      "description": "Accelerometer activity threshold in m/s²: Minimal absolute value for an accelerometer reading to be considered movement.",
       "type": "number",
       "minimum": 0,
-      "maximum": 19.6133,
-      "examples": [0.1]
+      "maximum": 78.4532,
+      "examples": [10.0]
+    },
+    "accith": {
+      "description": "Accelerometer inactivity threshold in m/s²: Maximum absolute value for an accelerometer reading to be considered stillness. Should be lower than the activity threshold.",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 78.4532,
+      "examples": [5.0]
+    },
+    "accito": {
+      "description": "Accelerometer inactivity timeout in s: Hysteresis timeout for stillness detection.",
+      "type": "number",
+      "minimum": 0.080,
+      "maximum": 5242.880,
+      "examples": [1.0]
     },
     "nod": {
       "description": "List of modules which should be disabled when sampling data.",
@@ -55,5 +69,5 @@
       "examples": [["gnss"], ["ncell"], ["gnss", "ncell"]]
     }
   },
-  "required": ["act", "actwt", "mvres", "mvt", "gnsst", "acct", "nod"]
+  "required": ["act", "actwt", "mvres", "mvt", "gnsst", "accath", "accith", "accito", "nod"]
 }

--- a/docs/cloud-protocol/cfg.schema.json
+++ b/docs/cloud-protocol/cfg.schema.json
@@ -54,8 +54,8 @@
     "accito": {
       "description": "Accelerometer inactivity timeout in s: Hysteresis timeout for stillness detection.",
       "type": "number",
-      "minimum": 0.080,
-      "maximum": 5242.880,
+      "minimum": 0.08,
+      "maximum": 5242.88,
       "examples": [1.0]
     },
     "nod": {
@@ -69,5 +69,15 @@
       "examples": [["gnss"], ["ncell"], ["gnss", "ncell"]]
     }
   },
-  "required": ["act", "actwt", "mvres", "mvt", "gnsst", "accath", "accith", "accito", "nod"]
+  "required": [
+    "act",
+    "actwt",
+    "mvres",
+    "mvt",
+    "gnsst",
+    "accath",
+    "accith",
+    "accito",
+    "nod"
+  ]
 }

--- a/docs/cloud-protocol/state.desired.azure.json
+++ b/docs/cloud-protocol/state.desired.azure.json
@@ -5,7 +5,9 @@
     "actwt": 60,
     "mvres": 60,
     "mvt": 3600,
-    "acct": 1.2,
+    "accath": 10.0,
+    "accith": 5.0,
+    "accito": 1.0,
     "nod": []
   },
   "firmware": {

--- a/docs/cloud-protocol/state.reported.aws.json
+++ b/docs/cloud-protocol/state.reported.aws.json
@@ -28,7 +28,9 @@
     "actwt": 60,
     "mvres": 60,
     "mvt": 3600,
-    "acct": 1.2,
+    "accath": 10.0,
+    "accith": 5.0,
+    "accito": 1.0,
     "nod": []
   },
   "dev": {

--- a/docs/cloud-protocol/state.reported.azure.json
+++ b/docs/cloud-protocol/state.reported.azure.json
@@ -28,7 +28,9 @@
     "actwt": 60,
     "mvres": 60,
     "mvt": 3600,
-    "acct": 1.2,
+    "accath": 10.0,
+    "accith": 5.0,
+    "accito": 1.0,
     "nod": []
   },
   "dev": {


### PR DESCRIPTION
This patch extends the existing accelerometer configuration options.
Its device-side pendant can be found in https://github.com/nrfconnect/sdk-nrf/pull/8020.

BREAKING CHANGE: the "acct" config property has been renamed to "accath",
and the properties "accith" and "accito" are introduced.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>