### PR TITLE
AWS: source code stack no longer needed

### DIFF
--- a/docs/aws/GettingStarted/Deploy.rst
+++ b/docs/aws/GettingStarted/Deploy.rst
@@ -10,11 +10,8 @@ The following commands set up the necessary resources in your AWS account:
     # ~/nrf-asset-tracker/aws
 
     # One-time operation to support large CloudFormation templates in CDK
-    npx cdk -a 'node --loader tsx cdk/cloudformation-sourcecode.ts' bootstrap aws://`aws sts get-caller-identity | jq -r '.Account' | tr -d '\n'`/${AWS_REGION}
+    npx cdk bootstrap aws://`aws sts get-caller-identity | jq -r '.Account' | tr -d '\n'`/${AWS_REGION}
 
-    # Create the S3 Bucket for publishing the lambdas
-    npx cdk -a 'node --loader tsx cdk/cloudformation-sourcecode.ts' deploy
-    
     # Deploy the example (see the note below)
     #   It will prompt:
     #     Do you wish to deploy these changes (y/n)?

--- a/docs/aws/Uninstalling.rst
+++ b/docs/aws/Uninstalling.rst
@@ -20,7 +20,3 @@ To uninstall the nRF Asset Tracker, execute the listed commands.
     # The CloudFormation distributions especially take a long time to get deleted
     npx cdk destroy --all
     
-    # Delete the Source Code Stack 
-    SOURCE_CODE_BUCKET=`aws cloudformation describe-stacks --stack-name ${STACK_NAME:-nrf-asset-tracker}-sourcecode | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "bucketName") | .OutputValue'` 
-    aws s3 rb s3://$SOURCE_CODE_BUCKET --force
-    npx cdk -a 'node --loader tsx cdk/cloudformation-sourcecode.ts' destroy -f '*'


### PR DESCRIPTION
See https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/pull/1339
