### PR TITLE
Add a new workflow to upload docs to zoomin

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -89,7 +89,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run publish-docs-zoomin.yaml --field name=asset-tracker-docs-${{ github.sha }} --ref ${{ github.ref }}
+          gh workflow run publish-docs-zoomin.yaml --field name=asset-tracker-docs-${{ github.sha }} --ref ${{ github.head_ref }}
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -1,9 +1,11 @@
 name: PR checks
 
-on: pull_request
+on:
+  pull_request:
 
 permissions:
   packages: write
+  actions: write
 
 jobs:
   docker:
@@ -82,6 +84,12 @@ jobs:
           if-no-files-found: error
           name: asset-tracker-docs-${{ github.sha }}
           path: build/html/
+
+      - name: Trigger publish docs zoomin workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-docs-zoomin.yaml --field name=asset-tracker-docs-${{ github.sha }} --ref ${{ github.ref }}
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-docs-zoomin.yaml
+++ b/.github/workflows/publish-docs-zoomin.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cd ${{ env.DOWNLOAD_DIR }}
           touch custom.properties
-          echo "manual.title=${ZOOMIN_TITLE// /_}" >> custom.properties
+          echo "manual.name=${ZOOMIN_TITLE// /_}" >> custom.properties
           echo "booktitle=${ZOOMIN_BOOK_TITLE}" >> custom.properties
 
           ZIP_FILENAME=${{ github.workspace }}/zoomin_nrf_asset_tracker_${{ github.sha }}.zip

--- a/.github/workflows/publish-docs-zoomin.yaml
+++ b/.github/workflows/publish-docs-zoomin.yaml
@@ -1,0 +1,63 @@
+name: Publish documentation to Zoomin
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: Artifact name to be published to Zoomin
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish the documentation
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DOWNLOAD_DIR=$(openssl rand -hex 8)
+          echo "DOWNLOAD_DIR=${DOWNLOAD_DIR}" >> $GITHUB_ENV
+          gh run download --name ${{ github.event.inputs.name }} --dir "${DOWNLOAD_DIR}"
+
+      - name: Install dependencies
+        run: |
+          sudo apt install -y sshpass
+
+      - name: Add custom.properties and zip
+        env:
+          ZOOMIN_TITLE: ${{ vars.ZOOMIN_TITLE || 'nrf-asset-tracker' }}
+          ZOOMIN_BOOK_TITLE: ${{ vars.ZOOMIN_BOOK_TITLE || 'nRF Asset Tracker' }}
+        run: |
+          cd ${{ env.DOWNLOAD_DIR }}
+          touch custom.properties
+          echo "manual.title=${ZOOMIN_TITLE// /_}" >> custom.properties
+          echo "booktitle=${ZOOMIN_BOOK_TITLE}" >> custom.properties
+
+          ZIP_FILENAME=${{ github.workspace }}/zoomin_nrf_asset_tracker_${{ github.sha }}.zip
+          echo "ZIP_FILENAME=${ZIP_FILENAME}" >> $GITHUB_ENV
+          zip -r -q "${ZIP_FILENAME}" .
+
+      - name: Upload Zoomin documentation
+        run: |
+          # Trust server
+          mkdir ~/.ssh
+          ssh-keyscan upload.zoominsoftware.io >> ~/.ssh/known_hosts
+
+          # Prepare key
+          echo "${{ secrets.ZOOMIN_KEY }}" | base64 -d > zoomin_key
+          chmod 600 zoomin_key
+
+          # Upload to Zoomin
+          sftp -v -i zoomin_key nordic@upload.zoominsoftware.io <<EOF
+          cd /nordic-be-dev.zoominsoftware.io/sphinx-html/incoming
+          put ${{ env.ZIP_FILENAME }}
+          quit
+          EOF


### PR DESCRIPTION
A new workflow will download a given artifact. Then adding `custom.properties` file and sftp to Zoomin server.

We can trigger this workflow using `gh` cli. The sample code is

```yaml
  - name: Trigger publish docs zoomin workflow
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    run: |
      gh workflow run publish-docs-zoomin.yaml --field name=<artifact name> --ref ${{ github.head_ref }}
```

- `--ref` parameter is the branch in which workflow is located

For this PR, we will publish docs to zoom in for all PRs if upload artifact is successful
