### PR TITLE
Public documents on Zoomin on saga branch

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -85,12 +85,6 @@ jobs:
           name: asset-tracker-docs-${{ github.sha }}
           path: build/html/
 
-      - name: Trigger publish docs zoomin workflow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run publish-docs-zoomin.yaml --field name=asset-tracker-docs-${{ github.sha }} --ref ${{ github.head_ref }}
-
   test:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -196,3 +196,10 @@ jobs:
           git commit -m "docs(${{ env.VERSION }}): update documentation for release ${{ env.RELEASE }}"
           git pull --rebase
           git push
+
+      - name: Trigger publish docs zoomin workflow
+        if: env.HAS_CHANGES == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-docs-zoomin.yaml --field name=asset-tracker-docs-${{ github.sha }}


### PR DESCRIPTION
Workflow will be trigger only when there is change on the docs the same mechanism we use to publish the documentation on github pages