### PR TITLE
NCS link update due to reorg

### DIFF
--- a/docs/guides/AutomateHEXFileBuilding.rst
+++ b/docs/guides/AutomateHEXFileBuilding.rst
@@ -3,7 +3,7 @@
 Automate building of HEX files for your nRF Connect SDK application
 ###################################################################
 
-Continuous delivery shortens the time to market of a product. The nRF9160 DK supports firmware over-the-air (FOTA) upgrades `for AWS <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/networking/aws_fota.html#lib-aws-fota>`_ and `for Azure <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/azure_fota/README.html>`_.
+Continuous delivery shortens the time to market of a product. The nRF9160 DK supports firmware over-the-air (FOTA) upgrades `for AWS <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/networking/aws_fota.html#lib-aws-fota>`_ and `for Azure <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/cellular/azure_fota/README.html>`_.
 As a developer, you most probably want to update the latest firmware, using FOTA, in your development kit every time the application changes.
 
 Continuous delivery requires automation of the process that builds the HEX file of an application.


### PR DESCRIPTION
NCS docs were reorganized.
One link to the Azure FOTA changed.
This PR fixes it.