### PR TITLE
fix: workflow failed due to lacking permission

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.CR_PAT }}
           commit-message: "style: auto-format source code"
           committer: "github-actions[bot] <actions@example.com>"
           author: "github-actions[bot] <actions@example.com>"


### PR DESCRIPTION
Reference to the error, https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/actions/runs/6174084454

This workflow will trigger another workflow to run on push. Therefore, the default GITHUB_TOKEN permission is not allowed, as specified in the documentation at https://github.com/peter-evans/create-pull-request.

To address this issue, we need to use a PAT (Personal Access Token) token instead, as recommended by GitHub. You can find more information on this in the documentation at https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs.