### PR TITLE
fix: updating links to TechDocs (Zoomin)

### DIFF
--- a/docs/aws/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/aws/GettingStarted/FirmwareConfiguration.rst
@@ -26,4 +26,4 @@ After completing the configuration, compile the firmware either :ref:`using your
 
 .. note::
 
-   See the documentation on `nRF9160: Asset Tracker v2 application <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_ for all available configuration options.
+   See the documentation on the `Asset Tracker v2 application <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html>`_ for all available configuration options.

--- a/docs/aws/GettingStarted/Index.rst
+++ b/docs/aws/GettingStarted/Index.rst
@@ -11,7 +11,7 @@ Before you start setting up the nRF Asset Tracker on AWS, make sure that you ful
 
 .. prerequisites_start
 
-* One of the `supported development kits  <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_.
+* One of the `supported development kits <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_.
 * :ref:`Necessary system requirements <system-requirements>`.
 * A :ref:`direnv <about-direnv>` plugin installed for your shell.
 * An AWS account with administrator access. To set up a new AWS account, see `Create and activate a new AWS account <https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/>`_.

--- a/docs/azure/GettingStarted/FirmwareConfiguration.rst
+++ b/docs/azure/GettingStarted/FirmwareConfiguration.rst
@@ -26,5 +26,5 @@ After completing the configuration, compile the firmware either :ref:`using your
 
 .. note::
 
-   See the documentation on `nRF9160: Asset Tracker v2 application <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_ for all available configuration options.
+   See the documentation on the `Asset Tracker v2 application <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html>`_ for all available configuration options.
       

--- a/docs/azure/GettingStarted/Index.rst
+++ b/docs/azure/GettingStarted/Index.rst
@@ -11,7 +11,7 @@ Before you start the setup of the nRF Asset Tracker on Azure, make sure that you
 
 .. prerequisites_start
 
-* One of the `supported development kits  <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_.
+* One of the `supported development kits <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_.
 * :ref:`Necessary system requirements <system-requirements>`.
 * A :ref:`direnv <about-direnv>` plugin installed for your shell.
 * An Azure account with administrator access. To set up a new Azure account, see `Create and activate a new Azure account <https://docs.microsoft.com/en-us/azure/guides/developer/azure-developer-guide#understanding-accounts-subscriptions-and-billing>`_.

--- a/docs/devices/FlashingCertificate/Provision.rst
+++ b/docs/devices/FlashingCertificate/Provision.rst
@@ -26,8 +26,8 @@ This will generate a new key on the device using the ``%KEYGEN`` AT command and 
 The generated certificate is then provisioned onto the device.
 The firmware will use the IMEI of the device as the MQTT client ID.
 
-Flashing the credentials can time out on the Thingy:91 when using USB if it is running an outdated `Connectivity bridge <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/connectivity_bridge/README.html>`_ application.
+Flashing the credentials can time out on the Thingy:91 when using USB if it is running an outdated `Connectivity bridge <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/connectivity_bridge/README.html>`_ application.
 The time-out happens when the CA certificate size is above the internal buffer size of the application.
-Make sure to update to the latest version of the Connectivity bridge application by following the `Updating the firmware in the nRF52840 SoC <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91_gsg.html#updating-the-firmware-in-the-nrf52840-soc>`_ guide.
+Make sure to update to the latest version of the Connectivity bridge application by following the `Updating the firmware in the nRF52840 SoC <hhttps://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/thingy91.html#updating_the_firmware_in_the_nrf52840_soc>`_ guide.
 
 .. body_end

--- a/docs/devices/Index.rst
+++ b/docs/devices/Index.rst
@@ -3,22 +3,22 @@
 Connect using a real device
 ###########################
 
-You can use any of the `supported development kits <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_ to connect to your account.
+You can use any of the `supported development kits <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/doc/asset_tracker_v2_description.html#requirements>`_ to connect to your account.
 
 To connect the device to your account, complete the following steps:
 
 1. Upgrade the modem firmware according to the instructions in the documentation:
 
-   * `nRF9160 DK modem upgrade <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/nrf9160_gs.html#updating-the-modem-firmware>`_
-   * `Thingy:91 modem upgrade <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91_gsg.html#update-the-modem-firmware-on-the-nrf9160-sip>`_
+   * `nRF9160 DK modem upgrade <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#updating_the_modem_firmware>`_
+   * `Thingy:91 modem upgrade <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/thingy91.html#update_the_modem_firmware_on_the_nrf9160_sip>`_
 
 #. :ref:`Provision the certificate <devices-provisioning-certificate>`.
 
    .. _program-the-firmware:
 #. Program the application firmware according to the instructions in the documentation:
 
-   * `nRF9160 DK application firmware update <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/nrf9160_gs.html#updating-the-application-firmware>`_
-   * `Thingy:91 application firmware update <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91_gsg.html#updating-the-firmware-in-the-nrf52840-soc>`_
+   * `nRF9160 DK application firmware update <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#updating_the_application_firmware>`_
+   * `Thingy:91 application firmware update <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/thingy91.html#program_the_nrf9160_sip_application>`_
 
 .. toctree::
    :titlesonly:

--- a/docs/firmware/Index.rst
+++ b/docs/firmware/Index.rst
@@ -3,7 +3,7 @@
 Firmware
 ########
 
-The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tracker v2 <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
+The firmware of the :ref:`nRF Asset Tracker <project>` is the `Asset Tracker v2 <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
 
 It is compatible with the :ref:`nRF Asset Tracker for AWS <index_aws>` and the :ref:`nRF Asset Tracker for Azure <index_azure>`.
 

--- a/docs/firmware/aws/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/aws/BuildingUsingLocalSystem.rst
@@ -16,7 +16,7 @@ Before building the project using your local system, complete the following step
 Prepare your system
 *******************
 
-Follow the `Getting Started Guide <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
+Follow the `installation instructions <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation.html>`_ of the nRF Connect SDK to set up your system for building the project.
 
 Clone the project and install the dependencies
 **********************************************

--- a/docs/firmware/aws/Index.rst
+++ b/docs/firmware/aws/Index.rst
@@ -3,7 +3,7 @@
 Firmware for the AWS cloud components
 #####################################
 
-The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tracker v2 <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
+The firmware of the :ref:`nRF Asset Tracker <project>` is the `Asset Tracker v2 <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
 
 It is compatible with the :ref:`nRF Asset Tracker for AWS <index_aws>`.
 

--- a/docs/firmware/azure/BuildingUsingLocalSystem.rst
+++ b/docs/firmware/azure/BuildingUsingLocalSystem.rst
@@ -16,7 +16,7 @@ Before building the project using your local system, complete the following step
 Prepare your system
 *******************
 
-Follow the `Getting started documentation <http://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html>`_ of the nRF Connect SDK to set up your system for building the project.
+Follow the `installation instructions <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation.html>`_ of the nRF Connect SDK to set up your system for building the project.
 
 Clone the project and install the dependencies
 **********************************************

--- a/docs/firmware/azure/Index.rst
+++ b/docs/firmware/azure/Index.rst
@@ -3,7 +3,7 @@
 Firmware for the Azure cloud components
 #######################################
 
-The firmware of the :ref:`nRF Asset Tracker <project>` is the `nRF9160: Asset Tracker v2 <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
+The firmware of the :ref:`nRF Asset Tracker <project>` is the `Asset Tracker v2 <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html>`_, which is a reference application developed using the `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_.
 
 It is compatible with the :ref:`nRF Asset Tracker for Azure <index_azure>`.
 

--- a/docs/guides/AutomateHEXFileBuilding.rst
+++ b/docs/guides/AutomateHEXFileBuilding.rst
@@ -3,7 +3,8 @@
 Automate building of HEX files for your nRF Connect SDK application
 ###################################################################
 
-Continuous delivery shortens the time to market of a product. The nRF9160 DK supports firmware over-the-air (FOTA) upgrades `for AWS <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/networking/aws_fota.html#lib-aws-fota>`_ and `for Azure <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/cellular/azure_fota/README.html>`_.
+Continuous delivery shortens the time to market of a product.
+The nRF9160 DK supports firmware over-the-air (FOTA) upgrades `for AWS <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/networking/aws_fota.html>`_ and `for Azure <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/networking/azure_fota.html>`_.
 As a developer, you most probably want to update the latest firmware, using FOTA, in your development kit every time the application changes.
 
 Continuous delivery requires automation of the process that builds the HEX file of an application.

--- a/docs/memfault/Index.rst
+++ b/docs/memfault/Index.rst
@@ -5,7 +5,7 @@ Memfault integration
 
 .. intro_start
 
-The `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_ provides `integration with Memfault <https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/external_comp/memfault.html>`_. 
+The `nRF Connect SDK <https://github.com/nrfconnect/sdk-nrf>`_ provides `integration with Memfault <https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/external_comp/memfault.html>`_. 
 
 By default, Memfault data is sent using HTTPS.
 Using MQTT is possible and preferred, because it reduces power consumption.


### PR DESCRIPTION
Updating NCS links to point to the new TechDocs site.